### PR TITLE
Change dev instances at SLAC to match the prod SLAC instances (parameters), add support for iDDS table partitions and scheduled jobs

### DIFF
--- a/rubin-panda-db-deploy/overlays/idds/dev/main/cnpg-panda-idds-database.yaml
+++ b/rubin-panda-db-deploy/overlays/idds/dev/main/cnpg-panda-idds-database.yaml
@@ -35,11 +35,11 @@ spec:
 
   resources:
     requests:
-      memory: 8Gi
-      cpu: 8
+      memory: 128Gi
+      cpu: 16
     limits:
-      memory: 16Gi
-      cpu: 16 
+      memory: 256Gi
+      cpu: 32
 
   storage:
     storageClass: wekafs--sdf-k8s01

--- a/rubin-panda-db-deploy/overlays/idds/dev/main/cnpg-panda-idds-database.yaml
+++ b/rubin-panda-db-deploy/overlays/idds/dev/main/cnpg-panda-idds-database.yaml
@@ -25,11 +25,13 @@ spec:
     reusePVC: true
 
   postgresql:
+    shared_preload_libraries: [ 'pg_cron', 'pg_partman_bgw' ]
     parameters:
-      shared_buffers: 2GB
+      shared_buffers: 32GB
       max_connections: "1000"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      work_mem: 128MB
 
   resources:
     requests:

--- a/rubin-panda-db-deploy/overlays/panda/dev/cnpg-panda-server-database.yaml
+++ b/rubin-panda-db-deploy/overlays/panda/dev/cnpg-panda-server-database.yaml
@@ -44,11 +44,11 @@ spec:
 
   resources:
     requests:
-      memory: 8Gi
-      cpu: 8
+      memory: 128Gi
+      cpu: 16
     limits:
-      memory: 16Gi
-      cpu: 16 
+      memory: 256Gi
+      cpu: 32
 
   storage:
     storageClass: wekafs--sdf-k8s01

--- a/rubin-panda-db-deploy/overlays/panda/dev/cnpg-panda-server-database.yaml
+++ b/rubin-panda-db-deploy/overlays/panda/dev/cnpg-panda-server-database.yaml
@@ -27,10 +27,11 @@ spec:
   postgresql:
     shared_preload_libraries: [ 'pg_cron', 'pg_partman_bgw' ]
     parameters:
-      shared_buffers: 2GB
+      shared_buffers: 32GB
       max_connections: "1000"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      work_mem: 128MB
     pg_hba:
       - local all panda trust
       - host all panda localhost trust


### PR DESCRIPTION
- Increase the postgres parameters for the dev SLAC instance to match the production instance. 
- Add support for scheduled (cron) jobs and partitions in the dev iDDS SLAC instance.
- Increase the resources request to match the production instance.