### PR TITLE
harvester: fix statefulset typo

### DIFF
--- a/helm/harvester/charts/harvester/templates/statefulset.yaml
+++ b/helm/harvester/charts/harvester/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   hostPath:
--    path: {{ .Values.persistentvolume.path }}
+    path: {{ .Values.persistentvolume.path }}
 ---
 {{- end }}
 # pv claim


### PR DESCRIPTION
Fixes `Error: YAML parse error on harvester/charts/harvester/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 19: did not find expected key`