### PR TITLE
Add support for global.existingTlsSecret to bigmon and panda

### DIFF
--- a/helm/bigmon/Chart.yaml
+++ b/helm/bigmon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/bigmon/charts/main/templates/statefulset.yaml
+++ b/helm/bigmon/charts/main/templates/statefulset.yaml
@@ -125,8 +125,19 @@ spec:
           configMap:
               name: {{ include "main.fullname" . }}-sandbox
         - name: {{ include "main.fullname" . }}-certs
+          {{- if .Values.global.existingTlsSecret }}
+          secret:
+              secretName: {{ .Values.global.existingTlsSecret }}
+              items:
+                # Map the TLS keys to the filenames bigmon expects
+                - key: tls.crt
+                  path: hostcert.pem
+                - key: tls.key
+                  path: hostkey.pem
+          {{- else }}
           secret:
               secretName: {{ .Values.global.secret }}-bigmon-certs
+          {{- end }}
   {{- if .Values.persistentvolume.create }}
         - name: {{ include "main.fullname" . }}-logs
           persistentVolumeClaim:

--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -4,6 +4,9 @@
 
 global:
   secret: "panda-secrets"
+  # Set the below to true to use certificates from an existing secret (e.g. cert-manager issued certs)
+  # If it's defined to a true value the helm-provided certificate files will be ignored.
+  existingTlsSecret: ""
 
 main:
   enabled: true

--- a/helm/panda/Chart.yaml
+++ b/helm/panda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/panda/charts/server/templates/statefulset.yaml
+++ b/helm/panda/charts/server/templates/statefulset.yaml
@@ -168,8 +168,21 @@ spec:
               - secret:
                   name: {{ .Values.global.secret }}-panda-token-cache
         - name: {{ include "server.fullname" . }}-certs
+          {{- if .Values.global.existingTlsSecret }}
+          secret:
+              secretName: {{ .Values.global.existingTlsSecret }}
+              items:
+                # Map the TLS keys to the filenames panda expects
+                - key: tls.crt
+                  path: hostcert.pem
+                - key: tls.key
+                  path: hostkey.pem
+                - key: tls.crt
+                  path: chain.pem
+          {{- else }}
           secret:
               secretName: {{ .Values.global.secret }}-panda-certs
+          {{- end }}
         - name: {{ include "server.fullname" . }}-cric-jsons-volume
           secret:
               secretName: {{ .Values.global.secret }}-cric-jsons

--- a/secrets/templates/bigmon.yaml
+++ b/secrets/templates/bigmon.yaml
@@ -87,6 +87,9 @@ stringData:
 
 ---
 # certs
+# Ingest certs from on-disk .pem files
+# unless we're expecting an existing secret defined via `bigmon.existingTlsSecret`.
+{{- if not .Values.bigmon.existingTlsSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -109,5 +112,6 @@ data:
     {{ $.Files.Get "files/bigmon_certs/hostcert.pem" | b64enc }}
   tls.key: |-
     {{ $.Files.Get "files/bigmon_certs/hostkey.pem" | b64enc }}
+{{- end }}
 
 {{- end }}

--- a/secrets/templates/panda.yaml
+++ b/secrets/templates/panda.yaml
@@ -76,19 +76,6 @@ stringData:
   {{ include "set_proxy" . | indent 2 }}
 
 ---
-# certs
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "secrets.fullname" . }}-panda-certs
-type: Opaque
-data:
-  {{- range $path, $_ := .Files.Glob "files/panda_certs/**.pem" }}
-  {{ base $path }}: |-
-    {{ $.Files.Get $path | b64enc }}
-  {{- end }}
-
----
 # auth
 apiVersion: v1
 kind: Secret
@@ -131,6 +118,22 @@ stringData:
   token_cache_config.json: |-
     {{ $token_cache_dict | toJson }}
 
+{{- if not .Values.panda.existingTlsSecret }}
+---
+# certs
+# Ingest certs from on-disk .pem files
+# unless we're expecting an existing secret defined via `panda.existingTlsSecret`.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secrets.fullname" . }}-panda-certs
+type: Opaque
+data:
+  {{- range $path, $_ := .Files.Glob "files/panda_certs/**.pem" }}
+  {{ base $path }}: |-
+    {{ $.Files.Get $path | b64enc }}
+  {{- end }}
+
 ---
 apiVersion: v1
 kind: Secret
@@ -142,5 +145,6 @@ data:
     {{ $.Files.Get "files/panda_certs/hostcert.pem" | b64enc }}
   tls.key: |-
     {{ $.Files.Get "files/panda_certs/hostkey.pem" | b64enc }}
+{{- end }}
 
 {{- end }}

--- a/secrets/values.yaml
+++ b/secrets/values.yaml
@@ -67,6 +67,9 @@ msgsvc:
 
 panda:
   enabled: true
+  # If this is set to true, certificates will not be ingested from certs on-disk,
+  # See the existingTlsSecret value in bigmon and panda charts where the secret name can be set.
+  existingTlsSecret: true
 
   database:
     backend: "postgres" # or oracle
@@ -130,6 +133,9 @@ idds:
 
 bigmon:
   enabled: true
+  # If this is set to true, certificates will not be ingested from certs on-disk,
+  # See the existingTlsSecret value in bigmon and panda charts where the secret name can be set.
+  existingTlsSecret: true
 
   base_url: "FIXME"
 


### PR DESCRIPTION
Currently certificates are assumed to be dropped into the Helm chart's files/ directory.

This can be problematic on certain deployments for two reasons:
1. It makes the chart not reusable if it's published.
2. It's quite common to have a component such as cert-manager which manages the issuing and renewal of certs in the cluster for you.

It should still support by default the existing workflow where certs are put into files/, unless the existingTlsSecret variables are defined, in which case the on-disk files are ignored and the existing secret is used.

Also note that I bumped the version! Let me know if you'd like to keep the "traditional" 0.1.0