### PR TITLE
Bump up server, jedi and database to the latest versions.

### DIFF
--- a/helm/panda/values.yaml
+++ b/helm/panda/values.yaml
@@ -11,8 +11,7 @@ jedi:
 
   # container image and tag
   image:
-    # tag: "0.6.0"
-    tag: "0.4.5"
+    tag: "0.6.12"
     # tag: "master"
 
   # PV with selector support
@@ -33,8 +32,7 @@ server:
 
   # container image and tag
   image:
-    # tag: "0.6.4"
-    tag: "0.4.2"
+    tag: "0.6.12"
     # tag: "master"
 
   # PV with selector support
@@ -96,7 +94,7 @@ postgres:
 
   # container image and tag
   image:
-    tag: "0.0.39"
+    tag: "0.0.45"
     #tag: "main"
 
   # PV with selector support


### PR DESCRIPTION
To fix the following issue (since jedi and server are on the same repo now):

```
  Warning  Failed     13s (x3 over 55s)  kubelet            Failed to pull image "ghcr.io/pandawms/panda-server:0.4.5": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/pandawms/panda-server:0.4.5": failed to resolve image: ghcr.io/pandawms/panda-server:0.4.5: not found
```

While Panda Server uses `ghcr.io/pandawms/panda-server:0.4.2`. 