### PR TITLE
Fix typos in documentation

### DIFF
--- a/helm/panda/charts/server/values.yaml
+++ b/helm/panda/charts/server/values.yaml
@@ -65,7 +65,7 @@ service:
 ingress:
   enabled: false
 
-  ### configration for CERN k8s
+  ### configuration for CERN k8s
   className: ""
   annotations:
     kubernetes.io/ingress.class: nginx
@@ -111,7 +111,7 @@ ingress:
 ingress_big:
   enabled: false
 
-  ### configration for CERN k8s
+  ### configuration for CERN k8s
   className: ""
   annotations:
     kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
## Summary

- Fix typo in `helm/panda/charts/server/values.yaml`: `configration` → `configuration` (2 occurrences)