### PR TITLE
Add ATLAS and DOMA harvester configs and sandbox scripts

### DIFF
--- a/helm/harvester/charts/harvester/queueconfig/atlas.panda_queueconfig.json
+++ b/helm/harvester/charts/harvester/queueconfig/atlas.panda_queueconfig.json
@@ -1,0 +1,417 @@
+{
+
+"production.pull": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "user",
+    "nQueueLimitWorkerRatio": 50,
+    "nQueueLimitWorkerMin": 100,
+    "nQueueLimitWorkerMax": 10000,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "NoJob",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "useSpool": false,
+      "useCRICGridCE": true,
+      "useCRIC": true,
+      "templateFile": "/opt/harvester/sandbox/atlas.submit_pilot.sdf",
+      "executableFile": "/opt/harvester/sandbox/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/harvester/run/x509up_u25606_pilot",
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://bigpanda-tb.cern.ch/condor_logs/condor_logs",      
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+"production.push": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "user",
+    "nQueueLimitWorker": 10000,
+    "nQueueLimitJobRatio":40,
+    "nQueueLimitJobMax": 1000,
+    "nQueueLimitJobMin":3,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "OneToOne",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "useSpool": false,
+      "useCRICGridCE": true,
+       "useCRIC": true,
+      "templateFile": "/opt/harvester/sandbox/atlas.submit_pilot.sdf",
+      "executableFile": "/opt/harvester/sandbox/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/harvester/run/x509up_u25606_pilot",
+      "tokenDir": "/data/tokens/ce/pilot",
+      "pandaTokenFilename": "panda_token",
+      "pandaTokenDir": "/data/tokens/pandaserver",
+      "pandaTokenKeyPath": "/opt/harvester/etc/auth/panda_token_key",      
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://bigpanda-tb.cern.ch/condor_logs/condor_logs",
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore",
+        "minRamCount"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+  "production_new_condor.pull": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "managed",
+    "nQueueLimitWorkerRatio": 50,
+    "nQueueLimitWorkerMin": 100,
+    "nQueueLimitWorkerMax": 10000,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "NoJob",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "condorSchedd": ["aipanda187.cern.ch"],
+      "condorPool": ["aipanda187.cern.ch:9618"],
+      "useSpool": false,
+      "useAtlasGridCE": false,
+      "useAtlasAGIS": true,
+      "templateFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/cloudscheduler-pilot2.sdf",
+      "executableFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/idds/x509up_u25606",
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://[ScheddHostname]/condor_logs",
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore",
+        "minRamCount"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+  "production_new_condor.push": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "managed",
+    "nQueueLimitWorkerRatio": 50,
+    "nQueueLimitWorkerMin": 100,
+    "nQueueLimitWorkerMax": 10000,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "OneToOne",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "condorSchedd": ["aipanda187.cern.ch"],
+      "condorPool": ["aipanda187.cern.ch:9618"],
+      "useSpool": false,
+      "useAtlasGridCE": false,
+      "useAtlasAGIS": true,
+      "templateFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/cloudscheduler-pilot2.sdf",
+      "executableFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/idds/x509up_u25606_pilot",
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://[ScheddHostname]/condor_logs",
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore",
+        "minRamCount"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+  "production_k8s.pull":{
+      "isTemplateQueue": true,
+      "prodSourceLabel":"managed",
+      "prodSourceLabelRandomWeightsPermille": {"ptest":10, "rc_test":10, "rc_test2":10, "rc_alrb":10},
+      "maxWorkers": 10000,
+      "nQueueLimitWorkerRatio": 40,
+      "nQueueLimitWorkerMin": 1,
+      "nQueueLimitWorkerMax": 100,
+      "nQueueLimitWorker":50,
+      "maxNewWorkersPerCycle":50,
+      "mapType":"NoJob",
+      "truePilot":true,
+      "allowJobMixture":true,
+      "maxSubmissionAttempts":3,
+      "walltimeLimit":1209600,
+      "prefetchEvents":false,
+      "preparator":{
+          "name":"DummyPreparator",
+          "module":"pandaharvester.harvesterpreparator.dummy_preparator"
+      },
+      "workerMaker":{
+          "name":"SimpleWorkerMaker",
+          "module":"pandaharvester.harvesterworkermaker.simple_worker_maker",
+          "jobAttributesToUse":[
+              "nCore"
+          ],
+          "pilotTypeRandomWeightsPermille": {"RC": 10, "ALRB": 10, "PT": 10}
+      },
+      "messenger":{
+          "name":"SharedFileMessenger",
+          "module":"pandaharvester.harvestermessenger.shared_file_messenger",
+          "jobSpecFileFormat":"cgi",
+          "accessPoint":"/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+      },
+      "stager":{
+          "name":"DummyStager",
+          "module":"pandaharvester.harvesterstager.dummy_stager"
+      },
+      "submitter":{
+          "name": "K8sSubmitter",
+          "module": "pandaharvester.harvestersubmitter.k8s_submitter",
+          "x509UserProxy": "/data/idds/x509up_u25606_pilot",
+          "proxySecretPath": "/proxy/x509up_u25606",
+          "logDir": "/var/cache/pandaserver/",
+          "logBaseURL": "https://ai-idds-01.cern.ch:25443/cache",
+          "cpuAdjustRatio": 90,
+          "memoryAdjustRatio": 100,
+          "nProcesses": 4
+      },
+      "monitor":{
+          "name": "K8sMonitor",
+          "module": "pandaharvester.harvestermonitor.k8s_monitor"
+      },
+      "sweeper":{
+          "name": "K8sSweeper",
+          "module": "pandaharvester.harvestersweeper.k8s_sweeper"
+      },
+      "credmanagers": [
+        {
+          "module": "pandaharvester.harvestercredmanager.k8s_secret_cred_manager",
+          "name": "K8sSecretCredManager",
+          "k8s_namespace": "${common.k8s_namespace}",
+          "k8s_config_file": "${common.k8s_config_file}",
+          "proxy_files": ["/data/idds/x509up_u25606"]
+        }
+      ],
+      "common": {
+          "k8s_yaml_file": "/opt/harvester/etc/k8s/job_cvmfs_prp_driver.yaml",
+          "k8s_config_file": "/data/idds/gcloud_config/.kube",
+          "k8s_namespace": "default"
+      }
+  },
+  "production_k8s.push":{
+      "isTemplateQueue": true,
+      "prodSourceLabel":"managed",
+      "nQueueLimitJobMax":10000,
+      "nQueueLimitJob": 10000,
+      "nQueueLimitWorker":10000,
+      "nQueueLimitWorkerRatio": 50,
+      "maxWorkers":50000,
+      "maxNewWorkersPerCycle":500,
+      "mapType":"OneToOne",
+      "truePilot":true,
+      "maxSubmissionAttempts":5,
+      "walltimeLimit":172800,
+      "prefetchEvents":false,
+      "preparator":{
+          "name":"DummyPreparator",
+          "module":"pandaharvester.harvesterpreparator.dummy_preparator"
+      },
+      "submitter":{
+          "name": "K8sSubmitter",
+          "module": "pandaharvester.harvestersubmitter.k8s_submitter",
+          "proxySecretPath":"/proxy/x509up_u25606",
+          "x509UserProxy": "/data/idds/x509up_u25606",
+          "logDir": "/var/cache/pandaserver/",
+          "logBaseURL": "https://ai-idds-01.cern.ch:25443/cache",
+          "cpuAdjustRatio": 90,
+          "memoryAdjustRatio": 100,
+          "nProcesses": 4
+      },
+      "workerMaker":{
+          "name":"SimpleWorkerMaker",
+          "module":"pandaharvester.harvesterworkermaker.simple_worker_maker",
+          "jobAttributesToUse":[
+              "nCore"
+          ]
+      },
+      "messenger":{
+          "name":"SharedFileMessenger",
+          "module":"pandaharvester.harvestermessenger.shared_file_messenger",
+          "jobSpecFileFormat":"cgi",
+          "accessPoint":"/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+      },
+      "stager":{
+          "name":"DummyStager",
+          "module":"pandaharvester.harvesterstager.dummy_stager"
+      },
+      "monitor":{
+          "name": "K8sMonitor",
+          "module": "pandaharvester.harvestermonitor.k8s_monitor"
+      },
+      "sweeper":{
+          "name": "K8sSweeper",
+          "module": "pandaharvester.harvestersweeper.k8s_sweeper"
+      },
+      "credmanagers": [
+        {
+          "module": "pandaharvester.harvestercredmanager.k8s_secret_cred_manager",
+          "name": "K8sSecretCredManager",
+          "k8s_namespace": "${common.k8s_namespace}",
+          "k8s_config_file": "${common.k8s_config_file}",
+          "proxy_files": ["/data/idds/x509up_u25606"]
+        }
+      ],
+      "common": {
+          "k8s_yaml_file": "/opt/harvester/etc/k8s/job_cvmfs_prp_driver.yaml",
+          "k8s_config_file": "/data/idds/gcloud_config/.kube",
+          "k8s_namespace": "default"
+      }
+  },
+
+"CERN": {
+        "templateQueueName": "production.push",
+        "queueStatus": "online",
+        "prodSourceLabel": "user",
+        "prodSourceLabelRandomWeightsPermille": {"rc_test":10, "rc_test2":10, "rc_alrb":10},        
+	"maxWorkers": 250
+  }
+
+}

--- a/helm/harvester/charts/harvester/queueconfig/doma.panda_queueconfig.json
+++ b/helm/harvester/charts/harvester/queueconfig/doma.panda_queueconfig.json
@@ -1,0 +1,1165 @@
+{
+
+"production.pull": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "managed",
+    "nQueueLimitWorkerRatio": 50,
+    "nQueueLimitWorkerMin": 100,
+    "nQueueLimitWorkerMax": 10000,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "NoJob",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "useSpool": false,
+      "useAtlasGridCE": false,
+      "useAtlasAGIS": true,
+      "templateFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/cloudscheduler-pilot2.sdf",
+      "executableFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/idds/x509up_u25606",
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://panda-doma.cern.ch/condor_logs/condor_logs",
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+"production.push": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "managed",
+    "nQueueLimitWorker": 10000,
+    "nQueueLimitJobRatio":40,
+    "nQueueLimitJobMax": 1000,
+    "nQueueLimitJobMin":3,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "OneToOne",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "useSpool": false,
+      "useAtlasGridCE": false,
+      "useAtlasAGIS": true,
+      "templateFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/cloudscheduler-pilot2.sdf",
+      "executableFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/idds/x509up_u25606",
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://panda-doma.cern.ch/condor_logs/condor_logs",
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore",
+        "minRamCount"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+  "production_new_condor.pull": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "managed",
+    "nQueueLimitWorkerRatio": 50,
+    "nQueueLimitWorkerMin": 100,
+    "nQueueLimitWorkerMax": 10000,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "NoJob",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "condorSchedd": ["aipanda187.cern.ch"],
+      "condorPool": ["aipanda187.cern.ch:9618"],
+      "useSpool": false,
+      "useAtlasGridCE": false,
+      "useAtlasAGIS": true,
+      "templateFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/cloudscheduler-pilot2.sdf",
+      "executableFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/idds/x509up_u25606",
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://[ScheddHostname]/condor_logs",
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore",
+        "minRamCount"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+  "production_new_condor.push": {
+    "isTemplateQueue": true,
+    "prodSourceLabel": "managed",
+    "nQueueLimitWorkerRatio": 50,
+    "nQueueLimitWorkerMin": 100,
+    "nQueueLimitWorkerMax": 10000,
+    "maxWorkers": 10,
+    "maxNewWorkersPerCycle": 100,
+    "mapType": "OneToOne",
+    "truePilot": true,
+    "maxSubmissionAttempts": 3,
+    "walltimeLimit": 1209600,
+    "prefetchEvents": false,
+    "preparator": {
+      "name": "DummyPreparator",
+      "module": "pandaharvester.harvesterpreparator.dummy_preparator"
+    },
+    "submitter": {
+      "name": "HTCondorSubmitter",
+      "module": "pandaharvester.harvestersubmitter.htcondor_submitter",
+      "condorSchedd": ["aipanda187.cern.ch"],
+      "condorPool": ["aipanda187.cern.ch:9618"],
+      "useSpool": false,
+      "useAtlasGridCE": false,
+      "useAtlasAGIS": true,
+      "templateFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/cloudscheduler-pilot2.sdf",
+      "executableFile": "/cephfs/atlpan/harvester/harvester_common/CERN_central_1/runpilot2-wrapper.sh",
+      "x509UserProxy": "/data/idds/x509up_u25606",
+      "logDir": "/var/log/condor_logs/condor_logs",
+      "logBaseURL": "https://[ScheddHostname]/condor_logs",
+      "nProcesses": 8
+    },
+    "workerMaker": {
+      "name": "SimpleWorkerMaker",
+      "module": "pandaharvester.harvesterworkermaker.simple_worker_maker",
+      "jobAttributesToUse": [
+        "nCore",
+        "minRamCount"
+      ],
+      "pilotTypeRandomWeightsPermille": {
+        "RC": 10,
+        "ALRB": 10,
+        "PT": 10
+      }
+    },
+    "messenger": {
+      "name": "SharedFileMessenger",
+      "module": "pandaharvester.harvestermessenger.shared_file_messenger",
+      "jobSpecFileFormat": "cgi",
+      "accessPoint": "/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+    },
+    "stager": {
+      "name": "DummyStager",
+      "module": "pandaharvester.harvesterstager.dummy_stager"
+    },
+    "monitor": {
+      "name": "HTCondorMonitor",
+      "module": "pandaharvester.harvestermonitor.htcondor_monitor",
+      "cancelUnknown": false
+    },
+    "sweeper": {
+      "name": "HTCondorSweeper",
+      "module": "pandaharvester.harvestersweeper.htcondor_sweeper"
+    }
+  },
+
+  "production_k8s.pull":{
+      "isTemplateQueue": true,
+      "prodSourceLabel":"managed",
+      "prodSourceLabelRandomWeightsPermille": {"ptest":10, "rc_test":10, "rc_test2":10, "rc_alrb":10},
+      "maxWorkers": 10000,
+      "nQueueLimitWorkerRatio": 40,
+      "nQueueLimitWorkerMin": 1,
+      "nQueueLimitWorkerMax": 100,
+      "nQueueLimitWorker":50,
+      "maxNewWorkersPerCycle":50,
+      "mapType":"NoJob",
+      "truePilot":true,
+      "allowJobMixture":true,
+      "maxSubmissionAttempts":3,
+      "walltimeLimit":1209600,
+      "prefetchEvents":false,
+      "preparator":{
+          "name":"DummyPreparator",
+          "module":"pandaharvester.harvesterpreparator.dummy_preparator"
+      },
+      "workerMaker":{
+          "name":"SimpleWorkerMaker",
+          "module":"pandaharvester.harvesterworkermaker.simple_worker_maker",
+          "jobAttributesToUse":[
+              "nCore"
+          ],
+          "pilotTypeRandomWeightsPermille": {"RC": 10, "ALRB": 10, "PT": 10}
+      },
+      "messenger":{
+          "name":"SharedFileMessenger",
+          "module":"pandaharvester.harvestermessenger.shared_file_messenger",
+          "jobSpecFileFormat":"cgi",
+          "accessPoint":"/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+      },
+      "stager":{
+          "name":"DummyStager",
+          "module":"pandaharvester.harvesterstager.dummy_stager"
+      },
+      "submitter":{
+          "name": "K8sSubmitter",
+          "module": "pandaharvester.harvestersubmitter.k8s_submitter",
+          "x509UserProxy": "/data/idds/x509up_u25606",
+          "proxySecretPath": "/proxy/x509up_u25606",
+          "logDir": "/var/cache/pandaserver/",
+          "logBaseURL": "https://ai-idds-01.cern.ch:25443/cache",
+          "cpuAdjustRatio": 90,
+          "memoryAdjustRatio": 100,
+          "nProcesses": 4
+      },
+      "monitor":{
+          "name": "K8sMonitor",
+          "module": "pandaharvester.harvestermonitor.k8s_monitor"
+      },
+      "sweeper":{
+          "name": "K8sSweeper",
+          "module": "pandaharvester.harvestersweeper.k8s_sweeper"
+      },
+      "credmanagers": [
+        {
+          "module": "pandaharvester.harvestercredmanager.k8s_secret_cred_manager",
+          "name": "K8sSecretCredManager",
+          "k8s_namespace": "${common.k8s_namespace}",
+          "k8s_config_file": "${common.k8s_config_file}",
+          "proxy_files": ["/data/idds/x509up_u25606"]
+        }
+      ],
+      "common": {
+          "k8s_yaml_file": "/opt/harvester/etc/k8s/job_cvmfs_prp_driver.yaml",
+          "k8s_config_file": "/data/idds/gcloud_config/.kube",
+          "k8s_namespace": "default"
+      }
+  },
+  "production_k8s.push":{
+      "isTemplateQueue": true,
+      "prodSourceLabel":"managed",
+      "nQueueLimitJobMax":10000,
+      "nQueueLimitJob": 10000,
+      "nQueueLimitWorker":10000,
+      "nQueueLimitWorkerRatio": 50,
+      "maxWorkers":50000,
+      "maxNewWorkersPerCycle":500,
+      "mapType":"OneToOne",
+      "truePilot":true,
+      "maxSubmissionAttempts":5,
+      "walltimeLimit":172800,
+      "prefetchEvents":false,
+      "preparator":{
+          "name":"DummyPreparator",
+          "module":"pandaharvester.harvesterpreparator.dummy_preparator"
+      },
+      "submitter":{
+          "name": "K8sSubmitter",
+          "module": "pandaharvester.harvestersubmitter.k8s_submitter",
+          "proxySecretPath":"/proxy/x509up_u25606",
+          "x509UserProxy": "/data/idds/x509up_u25606",
+          "logDir": "/var/cache/pandaserver/",
+          "logBaseURL": "https://ai-idds-01.cern.ch:25443/cache",
+          "cpuAdjustRatio": 90,
+          "memoryAdjustRatio": 100,
+          "nProcesses": 4
+      },
+      "workerMaker":{
+          "name":"SimpleWorkerMaker",
+          "module":"pandaharvester.harvesterworkermaker.simple_worker_maker",
+          "jobAttributesToUse":[
+              "nCore"
+          ]
+      },
+      "messenger":{
+          "name":"SharedFileMessenger",
+          "module":"pandaharvester.harvestermessenger.shared_file_messenger",
+          "jobSpecFileFormat":"cgi",
+          "accessPoint":"/var/log/condor_logs/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+      },
+      "stager":{
+          "name":"DummyStager",
+          "module":"pandaharvester.harvesterstager.dummy_stager"
+      },
+      "monitor":{
+          "name": "K8sMonitor",
+          "module": "pandaharvester.harvestermonitor.k8s_monitor"
+      },
+      "sweeper":{
+          "name": "K8sSweeper",
+          "module": "pandaharvester.harvestersweeper.k8s_sweeper"
+      },
+      "credmanagers": [
+        {
+          "module": "pandaharvester.harvestercredmanager.k8s_secret_cred_manager",
+          "name": "K8sSecretCredManager",
+          "k8s_namespace": "${common.k8s_namespace}",
+          "k8s_config_file": "${common.k8s_config_file}",
+          "proxy_files": ["/data/idds/x509up_u25606"]
+        }
+      ],
+      "common": {
+          "k8s_yaml_file": "/opt/harvester/etc/k8s/job_cvmfs_prp_driver.yaml",
+          "k8s_config_file": "/data/idds/gcloud_config/.kube",
+          "k8s_namespace": "default"
+      }
+  },
+
+"DOMA_LSST_GOOGLE_TEST_HIMEM_NON_PREEMPT": {
+    "queueStatus": "offline",
+    "maxWorkers": 2000,
+    "nQueueLimitJobMax":2000,
+    "nQueueLimitJob": 500,
+    "nQueueLimitWorker":5,
+    "nQueueLimitWorkerMin": 1,
+    "nQueueLimitWorkerMax": 20,
+    "maxNewWorkersPerCycle":50,
+    "mapType":"OneToOne",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_k8s.pull",
+    "common": {
+      "k8s_yaml_file": "/opt/harvester/etc/k8s/kube_job_non_preempt.yaml",
+      "k8s_config_file": "/data/idds/gcloud_config_rubin/kube_high_mem_non_preempt",
+      "k8s_namespace": "default"
+    }
+  },
+
+"DOMA_LSST_GOOGLE_TEST_HIMEM": {
+    "queueStatus": "offline",
+    "maxWorkers": 4050,
+    "nQueueLimitWorkerMin": 1,
+    "nQueueLimitWorkerMax": 50,
+    "nQueueLimitWorker":30,
+    "maxNewWorkersPerCycle":50,
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_k8s.pull",
+    "common": {
+      "k8s_yaml_file": "/opt/harvester/etc/k8s/kube_job.yaml",
+      "k8s_config_file": "/data/idds/gcloud_config_rubin/kube_high_mem",
+      "k8s_namespace": "default"
+    }
+  },
+
+"DOMA_LSST_GOOGLE_TEST_EXTRA_HIMEM_NON_PREEMPT": {
+    "maxWorkers": 50,
+    "nQueueLimitJob": 10,
+    "nQueueLimitWorkerMin": 1,
+    "nQueueLimitWorkerMax": 2,
+    "maxNewWorkersPerCycle":1,
+    "queueStatus": "offline",
+    "mapType":"OneToOne",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_k8s.pull",
+    "common": {
+      "k8s_yaml_file": "/opt/harvester/etc/k8s/kube_job_non_preempt.yaml",
+      "k8s_config_file": "/data/idds/gcloud_config_rubin/kube_extra_large_mem_non_preempt",
+      "k8s_namespace": "default"
+    }
+  },
+
+"DOMA_LSST_GOOGLE_TEST_EXTRA_HIMEM": {
+    "maxWorkers": 200,
+    "maxNewWorkersPerCycle":1,
+    "nQueueLimitWorkerMax": 1,
+    "queueStatus": "offline",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_k8s.pull",
+    "common": {
+      "k8s_yaml_file": "/opt/harvester/etc/k8s/kube_job.yaml",
+      "k8s_config_file": "/data/idds/gcloud_config_rubin/kube_extra_large_mem",
+      "k8s_namespace": "default"
+    }
+  },
+
+
+"DOMA_LSST_GOOGLE_MERGE": {
+    "queueStatus": "offline",
+    "maxWorkers": 20,
+    "nQueueLimitWorkerMin": 1,
+    "nQueueLimitWorkerMax": 5,
+    "maxNewWorkersPerCycle":5,
+    "queueStatus": "offline",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_k8s.pull",
+    "common": {
+      "k8s_yaml_file": "/opt/harvester/etc/k8s/kube_job.yaml",
+      "k8s_config_file": "/data/idds/gcloud_config_rubin/kube_merge",
+      "k8s_namespace": "default"
+    }
+  },
+
+"DOMA_LSST_GOOGLE_TEST": {
+  "queueStatus": "offline",
+  "nQueueLimitWorker":5000,
+  "maxNewWorkersPerCycle":200,
+  "nQueueLimitWorkerMax": 200,
+  "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+  "templateQueueName": "production_k8s.pull",
+  "common": {
+    "k8s_yaml_file": "/opt/harvester/etc/k8s/kube_job_moderate.yaml",
+    "k8s_config_file": "/data/idds/gcloud_config_rubin/kube_moderate_mem",
+    "k8s_namespace": "default"
+  }
+},
+ 
+"DOMA_LSST_DEV": {
+  "queueStatus": "offline",
+  "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+  "nQueueLimitJobMax":5,
+  "nQueueLimitJob": 5,
+  "nQueueLimitWorker":5,
+  "maxWorkers":3,
+  "maxNewWorkersPerCycle":2,
+  "mapType":"NoJob",
+  "truePilot":true,
+  "maxSubmissionAttempts":3,
+  "templateQueueName": "production_k8s.pull",
+  "common": {
+    "k8s_yaml_file": "/opt/harvester/etc/k8s/job_dev-prmon.yaml",
+    "k8s_config_file": "/data/idds/gcloud_config_rubin/kube_dev-gcs",
+    "k8s_namespace": "default"
+  }
+},
+
+ 
+"TEST_PQ": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "manage",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.pull",
+    "maxWorkers": 1,
+    "nQueueLimitWorkerMin": 1,
+    "nQueueLimitWorkerMax": 2,
+    "submitter": {
+                    "templateFile": "/opt/condor_test/grid_submit_pilot.sdf"
+      }
+  },
+
+"BNL_OSG_1": {
+    "queueStatus": "online",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 1000,
+    "maxNewWorkersPerCycle":50,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":1000,
+    "nQueueLimitWorkerMax": 1000,
+    "nQueueLimitJobMax":1000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 1000,
+    "nQueueLimitWorker":1000,
+    "submitter": {
+                    "templateFile": "/opt/harvester/sandbox/bnl_osg.submit_pilot_token_push.sdf",
+                    "x509UserProxy": "/data/harvester/run/x509up_u25606"      
+    }
+},
+
+"CNAF-DS-1": {
+    "queueStatus": "online",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 1000,
+    "maxNewWorkersPerCycle":50,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":1000,
+    "nQueueLimitWorkerMax": 1000,
+    "nQueueLimitJobMax":1000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 1000,
+    "nQueueLimitWorker":1000,
+    "submitter": {
+                    "templateFile": "/opt/harvester/sandbox/cnaf_darkside.submit_pilot_token_push.sdf",
+                    "x509UserProxy": "/data/harvester/darkside.short.proxy"
+      }
+},
+
+"BNL_OSG_2_old": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 1000,
+    "nQueueLimitWorkerRatio": 200,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 60,
+    "submitter": {
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_push_eic_works.sdf",
+                    "x509UserProxy": "/data/harvester/run/x509up_u25606"  
+    }
+},
+
+"BNL_OSG_2": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 50,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":50,
+    "nQueueLimitWorkerMax": 50,
+    "nQueueLimitJobMax":50,
+    "nQueueLimitJobMin":50,
+    "nQueueLimitJob": 50,
+    "nQueueLimitWorker":50,
+    "submitter": {
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_push_bnl_works.sdf",
+                    "x509UserProxy": "/data/harvester/run/x509up_u25606"          
+    }
+},
+
+"BNL_OSG_SPHENIX": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 10000,
+    "nQueueLimitWorkerRatio": 200,
+    "nQueueLimitWorkerMin": 20,
+    "nQueueLimitWorkerMax": 60,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+    "submitter": {
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_push_sphenix_works.sdf",
+                    "x509UserProxy": "/data/harvester/run/x509up_u25606"          
+    }
+  },
+
+"BNL_OSG_SPHENIX_TEST": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.pull",
+    "maxWorkers": 10000,
+    "nQueueLimitWorkerRatio": 200,
+    "nQueueLimitWorkerMin": 1,
+    "nQueueLimitWorkerMax": 10,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":20,
+    "submitter": {
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_pull_sphenix_works.sdf",
+                    "x509UserProxy": "/data/harvester/run/x509up_u25606"      
+    }
+  },
+
+"DOMA_LSST_SLAC_TEST": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 1,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":100,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_SLAC.sdf"
+      }
+  },
+
+"SLAC_TEST1": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.pull",
+    "maxWorkers": 700,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 200,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 20,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+                    "ceQueueName": "rubin",
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_SLAC.sdf"
+      }
+  },
+
+"SLAC_Rubin": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.pull",
+    "maxWorkers": 1000,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 200,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 100,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+            "ceQueueName": "rubin",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_SLAC_s3df_all.sdf"
+      }
+  },
+
+"SLAC_Rubin_Medium": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.pull",
+    "maxWorkers": 700,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 40,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+            "ceQueueName": "rubin",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_SLAC_s3df_all.sdf"
+      }
+  },
+
+"SLAC_Rubin_Himem": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.pull",
+    "maxWorkers": 700,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 40,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+            "ceQueueName": "rubin_himem",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_SLAC_s3df_all.sdf"
+      }
+  },
+
+"SLAC_Rubin_Extra_Himem": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 50,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 40,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+            "ceQueueName": "rubin_extra_himem",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_SLAC_s3df_all.sdf"
+      }
+  },
+
+"SLAC_Rubin_Merge": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 50,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 40,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+            "ceQueueName": "rubin_merge",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_SLAC_s3df_all.sdf"
+      }
+  },
+
+"SLAC_Rubin_SDF": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.pull",
+    "maxWorkers": 700,
+    "maxNewWorkersPerCycle":20,
+    "nQueueLimitWorkerRatio": 200,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 20,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+            "ceQueueName": "rubin",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_SLAC_all.sdf"
+      }
+  },
+
+"SLAC_Rubin_SDF_Big": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 500,
+    "maxNewWorkersPerCycle":10,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":3,
+    "nQueueLimitWorkerMax": 20,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1200,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":50,
+
+    "submitter": {
+            "ceQueueName": "rubin_himem",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_SLAC_all.sdf"
+      }
+  },
+
+"CC-IN2P3_TEST": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 3000,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle":40,
+    "nQueueLimitWorkerMin":40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "lsst",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://ccarcce01.in2p3.fr:9443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_IN2P3.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"CC-IN2P3_Rubin": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 3000,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle":40,
+    "nQueueLimitWorkerMin":40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "lsst",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://ccarcce01.in2p3.fr:9443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_IN2P3.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"CC-IN2P3_Rubin_Medium": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 700,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle":40,
+    "nQueueLimitWorkerMin":40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "lsst",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://ccarcce01.in2p3.fr:9443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_IN2P3.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"CC-IN2P3_Rubin_Himem": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 700,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle":40,
+    "nQueueLimitWorkerMin":40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "lsst",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://ccarcce01.in2p3.fr:9443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_IN2P3.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"CC-IN2P3_Rubin_Extra_Himem": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.push",
+    "maxWorkers": 50,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle":40,
+    "nQueueLimitWorkerMin":40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "lsst",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://ccarcce01.in2p3.fr:9443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_IN2P3.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"CC-IN2P3_Rubin_Merge": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.push",
+    "maxWorkers": 50,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle":40,
+    "nQueueLimitWorkerMin":40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":1000,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "lsst",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://ccarcce01.in2p3.fr:9443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_IN2P3.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"LANCS_TEST": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 3000,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle": 40,
+    "nQueueLimitWorkerMin": 40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "grid",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://grendel2.hec.lancs.ac.uk:443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_LANCS.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"LANCS_Rubin": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 3000,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle": 40,
+    "nQueueLimitWorkerMin": 40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "grid",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://grendel2.hec.lancs.ac.uk:443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_LANCS.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"LANCS_Rubin_Medium": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 700,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle": 40,
+    "nQueueLimitWorkerMin": 40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "grid",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://grendel2.hec.lancs.ac.uk:443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_LANCS.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"LANCS_Rubin_Himem": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.pull",
+    "maxWorkers": 700,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle": 40,
+    "nQueueLimitWorkerMin": 40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "grid",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://grendel2.hec.lancs.ac.uk:443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_pull_LSST_LANCS.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+
+"LANCS_Rubin_Extra_Himem": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.push",
+    "maxWorkers": 50,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle": 40,
+    "nQueueLimitWorkerMin": 40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "grid",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://grendel2.hec.lancs.ac.uk:443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_LANCS.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"LANCS_Rubin_Merge": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production_new_condor.push",
+    "maxWorkers": 50,
+    "nQueueLimitWorkerRatio": 500,
+    "maxNewWorkersPerCycle": 40,
+    "nQueueLimitWorkerMin": 40,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+            "ceQueueName": "grid",
+            "ceARCGridType": "arc",
+            "ceEndpoint": "https://grendel2.hec.lancs.ac.uk:443/arex/rest/1.0",
+            "templateFile": "/opt/condor_test/grid_submit_pilot_push_LSST_LANCS.sdf",
+            "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+
+"QMUL_TEST": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "managed",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 12,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":100,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+                    "useAtlasGridCE": true,
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_push_nordugrid.sdf",
+                    "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  },
+"RAL_TEST": {
+    "queueStatus": "offline",
+    "prodSourceLabel": "test",
+    "prodSourceLabelRandomWeightsPermille": {"rc_test":0, "rc_test2":0, "rc_alrb":0},
+    "templateQueueName": "production.push",
+    "maxWorkers": 12,
+    "nQueueLimitWorkerRatio": 500,
+    "nQueueLimitWorkerMin":100,
+    "nQueueLimitWorkerMax": 500,
+    "nQueueLimitJobMax":10000,
+    "nQueueLimitJobMin":100,
+    "nQueueLimitJob": 10000,
+    "nQueueLimitWorker":10000,
+
+    "submitter": {
+                    "useAtlasGridCE": true,
+                    "templateFile": "/opt/condor_test/grid_submit_pilot_push_nordugrid.sdf",
+                    "x509UserProxy": "/data/idds/x509up_u25606_lsst"
+      }
+  }
+
+}

--- a/helm/harvester/charts/harvester/sandbox/atlas.init-harvester
+++ b/helm/harvester/charts/harvester/sandbox/atlas.init-harvester
@@ -1,0 +1,10 @@
+#!/bin/bash
+# copy certs and set permission
+rm -rf /data/harvester/run
+mkdir /data/harvester/run
+cp /opt/harvester/etc/auth/atlpilo1RFC.plain /data/harvester/run/atlpilo1RFC.plain
+chmod 600 /data/harvester/run/atlpilo1RFC.plain
+
+# vomses file to refer to the atlas VOMS server
+echo '"atlas" "voms-atlas-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=atlas-auth.cern.ch" "atlas" "24"' >> /etc/vomses
+

--- a/helm/harvester/charts/harvester/sandbox/atlas.run-harvester-crons
+++ b/helm/harvester/charts/harvester/sandbox/atlas.run-harvester-crons
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# renew vomsproxy
+while true; do bash /opt/harvester/sandbox/atlas.vomsproxy-renew; sleep 3600; done &
+

--- a/helm/harvester/charts/harvester/sandbox/atlas.runpilot2-wrapper.sh
+++ b/helm/harvester/charts/harvester/sandbox/atlas.runpilot2-wrapper.sh
@@ -1,0 +1,1019 @@
+#!/bin/bash
+#
+# pilot2 wrapper used at CERN central pilot factories
+#
+# https://google.github.io/styleguide/shell.xml
+
+VERSION=20220211a-master
+
+function err() {
+  dt=$(date --utc +"%Y-%m-%d %H:%M:%S,%3N [wrapper]")
+  echo "$dt $@" >&2
+}
+
+function log() {
+  dt=$(date --utc +"%Y-%m-%d %H:%M:%S,%3N [wrapper]")
+  echo "$dt $@"
+}
+
+function get_workdir {
+  if [[ ${piloturl} == 'local' && ${harvesterflag} == 'false' ]]; then
+    echo $(pwd)
+    return 0
+  fi
+
+  if [[ ${harvesterflag} == 'true' ]]; then
+    # test if Harvester WorkFlow is OneToMany aka "Jumbo" Jobs
+    if [[ ${workflowarg} == 'OneToMany' ]]; then
+      if [[ -n ${!harvesterarg} ]]; then
+        templ=$(pwd)/atlas_${!harvesterarg}
+        mkdir ${templ}
+        echo ${templ}
+        return 0
+      fi
+    else
+      echo $(pwd)
+      return 0
+    fi
+  fi
+
+  if [[ -n "${OSG_WN_TMP}" ]]; then
+    templ=${OSG_WN_TMP}/atlas_XXXXXXXX
+  elif [[ -n "${TMPDIR}" ]]; then
+    templ=${TMPDIR}/atlas_XXXXXXXX
+  else
+    templ=$(pwd)/atlas_XXXXXXXX
+  fi
+  tempd=$(mktemp -d $templ)
+  echo ${tempd}
+}
+
+function check_python2() {
+  pybin=$(which python2)
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: python2 not found in PATH"
+    err "FATAL: python2 not found in PATH"
+    if [[ -z "${PATH}" ]]; then
+      log "In fact, PATH env var is unset mon amie"
+      err "In fact, PATH env var is unset mon amie"
+    fi
+    log "PATH content is ${PATH}"
+    err "PATH content is ${PATH}"
+    apfmon_fault 1
+    sortie 1
+  fi
+    
+  pyver=$($pybin -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
+  # we don't want python3 if requesting python2 explicitly
+  if [[ ${pyver} -ge 30 ]] ; then
+    log "ERROR: this site has python > 3.0, but only python2 requested"
+    err "ERROR: this site has python > 3.0, but only python2 requested"
+    apfmon_fault 1
+    sortie 1
+  fi
+
+  # check if native python version > 2.6
+  if [[ ${pyver} -ge 26 ]] ; then
+    log "Native python version is > 2.6 (${pyver})"
+    log "Using ${pybin} for python compatibility"
+    return
+  else
+    log "ERROR: this site has native python < 2.6"
+    err "ERROR: this site has native python < 2.6"
+    log "Native python ${pybin} is old: ${pyver}"
+  
+    # Oh dear, we're doomed...
+    log "FATAL: Failed to find a compatible python, exiting"
+    err "FATAL: Failed to find a compatible python, exiting"
+    apfmon_fault 1
+    sortie 1
+  fi
+}
+
+function setup_python3() {
+  # setup python3 from ALRB, default for grid sites
+  if [[ ${localpyflag} == 'true' ]]; then
+    log "localpyflag is true so we skip ALRB python3"
+  elif [[ ${ATLAS_LOCAL_PYTHON} == 'true' ]]; then
+    # email thread 7/7/21 dealing with LRZ SUSE
+    log "Env var ATLAS_LOCAL_PYTHON=true so skip ALRB python3"
+  else
+    log "Using ALRB to setup python3"
+    if [ -z "$ATLAS_LOCAL_ROOT_BASE" ]; then
+        export ATLAS_LOCAL_ROOT_BASE="/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase"
+    fi
+    export ALRB_LOCAL_PY3="YES"
+    source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh --quiet
+    lsetup -q "python pilot-default" 
+  fi
+}
+
+function check_python3() {
+  pybin=$(which python3)
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: python3 not found in PATH"
+    err "FATAL: python3 not found in PATH"
+    if [[ -z "${PATH}" ]]; then
+      log "In fact, PATH env var is unset mon amie"
+      err "In fact, PATH env var is unset mon amie"
+    fi
+    log "PATH content: ${PATH}"
+    err "PATH content: ${PATH}"
+    apfmon_fault 1
+    sortie 1
+  fi
+    
+  pyver=$($pybin -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
+  # check if python version > 3.6
+  if [[ ${pyver} -ge 36 ]] ; then
+    log "Python version is > 3.6 (${pyver})"
+    log "Using ${pybin} for python compatibility"
+  else
+    log "ERROR: this site has python < 3.6"
+    err "ERROR: this site has python < 3.6"
+    log "Python ${pybin} is old: ${pyver}"
+  
+    # Oh dear, we're doomed...
+    log "FATAL: Failed to find a compatible python, exiting"
+    err "FATAL: Failed to find a compatible python, exiting"
+    apfmon_fault 1
+    sortie 1
+  fi
+}
+
+function check_proxy() {
+  voms-proxy-info -all
+  if [[ $? -ne 0 ]]; then
+    log "WARNING: error running: voms-proxy-info -all"
+    err "WARNING: error running: voms-proxy-info -all"
+    arcproxy -I
+    if [[ $? -eq 127 ]]; then
+      log "FATAL: error running: arcproxy -I"
+      err "FATAL: error running: arcproxy -I"
+      apfmon_fault 1
+      sortie 1
+    fi
+  fi
+}
+
+function check_cvmfs() {
+  export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-/cvmfs/atlas.cern.ch/repo/sw}
+  if [[ -d ${VO_ATLAS_SW_DIR} ]]; then
+    log "Found atlas software repository: ${VO_ATLAS_SW_DIR}"
+  else
+    log "ERROR: atlas software repository NOT found: ${VO_ATLAS_SW_DIR}"
+    log "FATAL: Failed to find atlas software repository"
+    err "FATAL: Failed to find atlas software repository"
+    apfmon_fault 1
+    sortie 1
+  fi
+}
+  
+function setup_alrb() {
+  log 'NOTE: rucio,davix,xrootd setup now done in local site setup atlasLocalSetup.sh'
+  if [[ ${iarg} == "RC" ]]; then
+    log 'RC pilot requested, setting ALRB_rucioVersion=testing'
+    export ALRB_rucioVersion=testing
+  fi
+  if [[ ${iarg} == "ALRB" ]]; then
+    log 'ALRB pilot requested, setting ALRB env vars to testing'
+    export ALRB_adcTesting=YES
+  fi
+  export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase}
+  export ALRB_userMenuFmtSkip=YES
+  export ALRB_noGridMW=${ALRB_noGridMW:-NO}
+
+  if [[ ${ALRB_noGridMW} == "YES" ]]; then
+    log "Site has set ALRB_noGridMW=YES so use site native install rather than ALRB"
+    if [[ ${tflag} == 'true' ]]; then
+      log 'Skipping proxy checks due to -t flag'
+    else
+      check_vomsproxyinfo || check_arcproxy
+      if [[ $? -eq 1 ]]; then
+        log "FATAL: Site MW being used but proxy tools not found"
+        err "FATAL: Site MW being used but proxy tools not found"
+        apfmon_fault 1
+        sortie 1
+      fi
+    fi
+  else
+    log "Will use ALRB MW because ALRB_noGridMW=NO (default)"
+  fi
+
+}
+
+function setup_local() {
+  log "Looking for ${VO_ATLAS_SW_DIR}/local/setup.sh"
+  if [[ -f ${VO_ATLAS_SW_DIR}/local/setup.sh ]]; then
+    if [[ ${pythonversion} == '3' ]]; then
+      log "Sourcing ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg} -p python3"
+      source ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg} -p python3
+    else
+      log "Sourcing ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg}"
+      source ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg}
+    fi
+  else
+    log 'WARNING: No ATLAS local setup found'
+    err 'WARNING: this site has no local setup ${VO_ATLAS_SW_DIR}/local/setup.sh'
+  fi
+  # OSG MW setup, skip if not using ALRB Grid MW
+  if [[ ${ALRB_noGridMW} == "YES" ]]; then
+    if [[ -f ${OSG_GRID}/setup.sh ]]; then
+      log "Setting up OSG MW using ${OSG_GRID}/setup.sh"
+      source ${OSG_GRID}/setup.sh
+    else
+      log 'Env var ALRB_noGridMW=NO, not sourcing ${OSG_GRID}/setup.sh'
+    fi
+  fi
+
+}
+
+function setup_shoal() {
+  log "will set FRONTIER_SERVER with shoal"
+
+  outputstr=$(env -i FRONTIER_SERVER="$FRONTIER_SERVER"  /bin/bash -l -c "shoal-client -f")
+  if [[ $? -eq 0 ]] &&  [[ -n "${outputstr}" ]] ; then
+    export FRONTIER_SERVER=${outputstr}
+  else
+    log "WARNING: shoal-client had non-zero exit code or empty output"
+  fi
+
+  log "FRONTIER_SERVER = $FRONTIER_SERVER"
+}
+
+function setup_harvester_symlinks() {
+  for datafile in `find ${HARVESTER_WORKDIR} -maxdepth 1 -type l -exec /usr/bin/readlink -e {} ';'`; do
+      symlinkname=$(basename $datafile)
+      ln -s $datafile $symlinkname
+  done      
+}
+
+
+function check_vomsproxyinfo() {
+  out=$(voms-proxy-info --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Check version: ${out}"
+    return 0
+  else
+    log "voms-proxy-info not found"
+    return 1
+  fi
+}
+
+function check_arcproxy() {
+  out=$(arcproxy --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Check version: ${out}"
+    return 0
+  else
+    log "arcproxy not found"
+    return 1
+  fi
+}
+
+function pilot_cmd() {
+
+  # test if not harvester job 
+  if [[ ${harvesterflag} == 'false' ]] ; then  
+    if [[ -n ${pilotversion} ]]; then
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} --pilot-user=ATLAS ${pilotargs}"
+    else
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} --pilot-user=ATLAS ${pilotargs}"
+    fi
+  else
+    # check to see if we are running OneToMany Harvester workflow (aka Jumbo Jobs)
+    if [[ ${workflowarg} == 'OneToMany' ]] && [ -z ${HARVESTER_PILOT_WORKDIR+x} ] ; then
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} -a ${HARVESTER_PILOT_WORKDIR} --pilot-user=ATLAS ${pilotargs}"
+    else
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} --pilot-user=ATLAS ${pilotargs}"
+    fi
+  fi
+  echo ${cmd}
+}
+
+function sing_cmd() {
+  cmd="$BINARY_PATH exec $SINGULARITY_OPTIONS $IMAGE_PATH $0 $myargs"
+  echo ${cmd}
+}
+
+function sing_env() {
+  export SINGULARITYENV_X509_USER_PROXY=${X509_USER_PROXY}
+  if [[ -n "${ATLAS_LOCAL_AREA}" ]]; then
+    export SINGULARITYENV_ATLAS_LOCAL_AREA=${ATLAS_LOCAL_AREA}
+  fi
+  if [[ -n "${TMPDIR}" ]]; then
+    export SINGULARITYENV_TMPDIR=${TMPDIR}
+  fi
+  if [[ -n "${RECOVERY_DIR}" ]]; then
+    export SINGULARITYENV_RECOVERY_DIR=${RECOVERY_DIR}
+  fi
+}
+
+function get_piloturl() {
+  local version=$1
+  local pilotdir=file:///cvmfs/atlas.cern.ch/repo/sw/PandaPilot/tar
+
+  if [[ -n ${piloturl} ]]; then
+    echo ${piloturl}
+    return 0
+  fi
+
+  if [[ ${version} == '1' ]]; then
+    log "FATAL: pilot version 1 requested, not supported by this wrapper"
+    err "FATAL: pilot version 1 requested, not supported by this wrapper"
+    apfmon 1
+    sortie 1
+  elif [[ ${version} == '2' ]]; then
+    pilottar=${pilotdir}/pilot2.tar.gz
+  elif [[ ${version} == 'latest' ]]; then
+    pilottar=${pilotdir}/pilot2.tar.gz
+  elif [[ ${version} == 'current' ]]; then
+    pilottar=${pilotdir}/pilot2.tar.gz
+  elif [[ ${version} == '3' ]]; then
+    pilottar=${pilotdir}/pilot3.tar.gz
+    pilotbase='pilot3'
+  else
+    pilottar=${pilotdir}/pilot2-${version}.tar.gz
+  fi
+  echo ${pilottar}
+}
+
+function get_pilot() {
+
+  local url=$1
+
+  if [[ ${harvesterflag} == 'true' ]] && [[ ${workflowarg} == 'OneToMany' ]]; then
+    cp -v ${HARVESTER_WORK_DIR}/pilot2.tar.gz .
+  fi
+
+  if [[ ${url} == 'local' ]]; then
+    log "piloturl=local so download not needed"
+    
+    if [[ -f pilot2.tar.gz ]]; then
+      log "local tarball pilot2.tar.gz exists OK"
+      tar -xzf pilot2.tar.gz
+      if [[ $? -ne 0 ]]; then
+        log "ERROR: pilot extraction failed for pilot2.tar.gz"
+        err "ERROR: pilot extraction failed for pilot2.tar.gz"
+        return 1
+      fi
+    elif [[ -f pilot3.tar.gz ]]; then
+      log "local tarball pilot3.tar.gz exists OK"
+      tar -xzf pilot3.tar.gz
+      if [[ $? -ne 0 ]]; then
+        log "ERROR: pilot extraction failed for pilot3.tar.gz"
+        err "ERROR: pilot extraction failed for pilot3.tar.gz"
+        return 1
+      fi
+    else
+      log "local pilot[23].tar.gz not found so assuming already extracted"
+    fi
+  else
+    curl --connect-timeout 30 --max-time 180 -sSL ${url} | tar -xzf -
+    if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+      log "ERROR: pilot download failed: ${url}"
+      err "ERROR: pilot download failed: ${url}"
+      return 1
+    fi
+  fi
+
+  if [[ -f ${pilotbase}/pilot.py ]]; then
+    log "File ${pilotbase}/pilot.py exists OK"
+    log "${pilotbase}/PILOTVERSION: $(cat ${pilotbase}/PILOTVERSION)"
+    return 0
+  else
+    log "ERROR: ${pilotbase}/pilot.py not found"
+    err "ERROR: ${pilotbase}/pilot.py not found"
+    return 1
+  fi
+}
+
+function muted() {
+  log "apfmon messages muted"
+}
+
+function apfmon_running() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+  echo -n "running 0 ${VERSION} ${qarg} ${APFFID}:${APFCID}" > /dev/udp/148.88.67.14/28527
+  resource=${GRID_GLOBAL_JOBHOST:-}
+  out=$(curl -ksS --connect-timeout 10 --max-time 20 -d uuid=${UUID} \
+             -d qarg=${qarg} -d state=wrapperrunning -d wrapper=${VERSION} \
+             -d gtag=${GTAG} -d resource=${resource} \
+             -d hid=${HARVESTER_ID} -d hwid=${HARVESTER_WORKER_ID} \
+             ${APFMON}/jobs/${APFFID}:${APFCID})
+  if [[ $? -eq 0 ]]; then
+    log $out
+  else
+    err "WARNING: wrapper monitor ${UUID}"
+  fi
+}
+
+function apfmon_exiting() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+  out=$(curl -ksS --connect-timeout 10 --max-time 20 \
+             -d state=wrapperexiting -d rc=$1 -d uuid=${UUID} \
+             -d ids="${pandaids}" -d duration=$2 \
+             ${APFMON}/jobs/${APFFID}:${APFCID})
+  if [[ $? -eq 0 ]]; then
+    log $out
+  else
+    err "WARNING: wrapper monitor ${UUID}"
+  fi
+}
+
+function apfmon_fault() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+
+  out=$(curl -ksS --connect-timeout 10 --max-time 20 \
+             -d state=wrapperfault -d rc=$1 -d uuid=${UUID} \
+             ${APFMON}/jobs/${APFFID}:${APFCID})
+  if [[ $? -eq 0 ]]; then
+    log $out
+  else
+    err "WARNING: wrapper monitor ${UUID}"
+  fi
+}
+
+function trap_handler() {
+  if [[ -n "${pilotpid}" ]]; then
+    log "WARNING: Caught $1, signalling pilot PID: $pilotpid"
+    kill -s $1 $pilotpid
+    wait
+  else
+    log "WARNING: Caught $1 prior to pilot starting"
+  fi
+}
+
+function sortie() {
+  ec=$1
+  if [[ $ec -eq 0 ]]; then
+    state=wrapperexiting
+  else
+    state=wrapperfault
+  fi
+
+  log "==== wrapper stdout END ===="
+  err "==== wrapper stderr END ===="
+
+  duration=$(( $(date +%s) - ${starttime} ))
+  log "${state} ec=$ec, duration=${duration}"
+  
+  if [[ ${mute} == 'true' ]]; then
+    muted
+  else
+    echo -n "${state} ${duration} ${VERSION} ${qarg} ${APFFID}:${APFCID}" > /dev/udp/148.88.67.14/28527
+  fi
+
+  exit $ec
+}
+
+function get_cricopts() {
+  container_opts=$(curl --silent $cricurl | grep container_options | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    cricopts=$(echo $container_opts | awk -F"\"" '{print $4}')
+    echo ${cricopts}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_catchall() {
+  local result
+  local content
+  result=$(curl --silent $cricurl | grep catchall | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    content=$(echo $result | awk -F"\"" '{print $4}')
+    echo ${content}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_environ() {
+  local result
+  local content
+  result=$(curl --silent $cricurl | grep environ | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    content=$(echo $result | awk -F"\"" '{print $4}')
+    echo ${content}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function check_singularity() {
+  BINARY_PATH="/cvmfs/atlas.cern.ch/repo/containers/sw/singularity/`uname -m`-el7/current/bin/singularity"
+  IMAGE_PATH="/cvmfs/atlas.cern.ch/repo/containers/fs/singularity/`uname -m`-centos7"
+  SINGULARITY_OPTIONS="$(get_cricopts) -B /cvmfs -B $PWD --cleanenv"
+  out=$(${BINARY_PATH} --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Singularity binary found, version $out"
+    log "Singularity binary path: ${BINARY_PATH}"
+  else
+    log "Singularity binary not found"
+  fi
+}
+
+function check_type() {
+  if [[ -f queuedata.json ]]; then
+    result=$(cat queuedata.json | grep container_type | grep 'singularity:wrapper')
+  else
+    result=$(curl --silent $cricurl | grep container_type | grep 'singularity:wrapper')
+  fi
+  if [[ $? -eq 0 ]]; then
+    log "CRIC container_type: singularity:wrapper found"
+    return 0
+  else
+    log "CRIC container_type: singularity:wrapper not found"
+    return 1
+  fi
+}
+
+
+function main() {
+  #
+  # Fail early, fail often^W with useful diagnostics
+  #
+  trap 'trap_handler SIGINT' SIGINT
+  trap 'trap_handler SIGTERM' SIGTERM
+  trap 'trap_handler SIGQUIT' SIGQUIT
+  trap 'trap_handler SIGSEGV' SIGSEGV
+  trap 'trap_handler SIGXCPU' SIGXCPU
+  trap 'trap_handler SIGUSR1' SIGUSR1
+  trap 'trap_handler SIGUSR2' SIGUSR2
+  trap 'trap_handler SIGBUS' SIGBUS
+
+  if [[ -z ${SINGULARITY_ENVIRONMENT} ]]; then
+    # SINGULARITY_ENVIRONMENT not set
+    echo "This is ATLAS pilot wrapper version: $VERSION"
+    echo "Please send development requests to p.love@lancaster.ac.uk"
+    echo
+    log "==== wrapper stdout BEGIN ===="
+    err "==== wrapper stderr BEGIN ===="
+    UUID=$(cat /proc/sys/kernel/random/uuid)
+    apfmon_running
+    log "${cricurl}"
+    echo
+    echo "---- Initial environment ----"
+    printenv | sort
+    echo
+    echo "---- PWD content ----"
+    pwd
+    ls -la
+    echo
+
+    echo "---- Check singularity details (development) ----"
+    cric_opts=$(get_cricopts)
+    if [[ $? -eq 0 ]]; then
+      log "CRIC container_options: $cric_opts"
+    else
+      log "WARNING: failed to get CRIC container_options"
+    fi
+
+    check_type
+    if [[ $? -eq 0 ]]; then
+      use_singularity=true
+      log "container_type contains singularity:wrapper, so use_singularity=true"
+    else
+      use_singularity=false
+    fi
+
+    if [[ ${use_singularity} = true ]]; then
+      # check if already in SINGULARITY environment
+      log 'SINGULARITY_ENVIRONMENT is not set'
+      sing_env
+      log 'Setting SINGULARITY_env'
+      check_singularity
+      export ALRB_noGridMW=NO
+      echo '   _____ _                   __           _ __        '
+      echo '  / ___/(_)___  ____ ___  __/ /___ ______(_) /___  __ '
+      echo '  \__ \/ / __ \/ __ `/ / / / / __ `/ ___/ / __/ / / / '
+      echo ' ___/ / / / / / /_/ / /_/ / / /_/ / /  / / /_/ /_/ /  '
+      echo '/____/_/_/ /_/\__, /\__,_/_/\__,_/_/  /_/\__/\__, /   '
+      echo '             /____/                         /____/    '
+      echo
+      cmd=$(sing_cmd)
+      echo "cmd: $cmd"
+      echo
+      log '==== singularity stdout BEGIN ===='
+      err '==== singularity stderr BEGIN ===='
+      $cmd &
+      singpid=$!
+      wait $singpid
+      log "singularity return code: $?"
+      log '==== singularity stdout END ===='
+      err '==== singularity stderr END ===='
+      log "==== wrapper stdout END ===="
+      err "==== wrapper stderr END ===="
+      exit 0
+    else
+      log 'Will NOT use singularity, at least not from the wrapper'
+    fi
+    echo
+  else
+    log 'SINGULARITY_ENVIRONMENT is set, run basic setup'
+    export ALRB_noGridMW=NO
+    df -h
+  fi
+
+  echo "---- Host details ----"
+  echo "hostname:" $(hostname -f)
+  echo "pwd:" $(pwd)
+  echo "whoami:" $(whoami)
+  echo "id:" $(id)
+  echo "getopt:" $(getopt -V 2>/dev/null)
+  echo "jq:" $(jq --version 2>/dev/null)
+  if [[ -r /proc/version ]]; then
+    echo "/proc/version:" $(cat /proc/version)
+  fi
+  echo "lsb_release:" $(lsb_release -d 2>/dev/null)
+  echo "SINGULARITY_ENVIRONMENT:" ${SINGULARITY_ENVIRONMENT}
+  
+  myargs=$@
+  echo "wrapper call: $0 $myargs"
+
+  cpuinfo_flags="flags: EMPTY"
+  if [ -f /proc/cpuinfo ]; then
+    cpuinfo_flags="$(grep '^flags' /proc/cpuinfo 2>/dev/null | sort -u 2>/dev/null)"
+    if [ -z "${cpuinfo_flags}" ]; then 
+      cpuinfo_flags="flags: EMPTY"
+    fi
+  else
+    cpuinfo_flags="flags: EMPTY"
+  fi
+  
+  echo "Flags from /proc/cpuinfo:"
+  echo ${cpuinfo_flags}
+  echo
+
+  
+  echo "---- Enter workdir ----"
+  echo "PAL TMPDIR: $TMPDIR"
+  echo "PAL ${TMPDIR}/atlas_XXXXXXXX"
+  echo "PAL mktemp: " $(mktemp -d ${TMPDIR}/atlas_XXXXXXXX)
+  mktemp -d ${TMPDIR}/atlas_XXXXXXXX
+  echo MKTEMP: $?
+  workdir=$(get_workdir)
+  log "Workdir: ${workdir}"
+  if [[ -f pandaJobData.out ]]; then
+    log "Copying job description to working dir"
+    cp pandaJobData.out $workdir/pandaJobData.out
+  fi
+  log "cd ${workdir}"
+  cd ${workdir}
+  if [[ ${harvesterflag} == 'true' ]]; then
+        export HARVESTER_PILOT_WORKDIR=${workdir}
+        log "Define HARVESTER_PILOT_WORKDIR : ${HARVESTER_PILOT_WORKDIR}"
+  fi
+  echo
+  
+  echo "---- Retrieve pilot code ----"
+  piloturl=$(get_piloturl ${pilotversion})
+  log "Using piloturl: ${piloturl}"
+
+  if grep -q "pilot3" <<< "$piloturl"; then
+    log "Pilot URL contains pilot3"
+    pilotbase='pilot3'
+  fi
+
+  if [[ ${pilotversion} == '3' ]]; then
+    log "Setting base to pilot3 since cmd line has pilotversion=3"
+    pilotbase='pilot3'
+  fi
+  echo
+
+  echo "---- Logstash overrides (devel Paul) ----"
+  result=$(get_catchall)
+  if [[ $? -eq 0 ]]; then
+    if grep -q "logging=logstash" <<< "$result"; then
+      if [[ ${pilotbase} == 'pilot3' && $jarg == 'managed' ]]; then
+        log 'WARNING: overriding pilot version pilot3->pilot2 for Paul test'
+        pilotbase='pilot2'
+        piloturl='file:///cvmfs/atlas.cern.ch/repo/sw/PandaPilot/tar/pilot2/pilot2.tar.gz'
+      fi
+    else
+      log 'Logstash not requested in CRIC catchall'
+    fi
+  else
+    log 'No content found in CRIC catchall'
+  fi
+  echo
+
+  get_pilot ${piloturl}
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: failed to get pilot code"
+    err "FATAL: failed to get pilot code"
+    apfmon_fault 1
+    sortie 1
+  fi
+  echo
+  
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping defining VO_ATLAS_SW_DIR due to --container flag'
+    log 'Skipping defining ATLAS_LOCAL_ROOT_BASE due to --container flag'
+  else
+    export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-/cvmfs/atlas.cern.ch/repo/sw}
+    export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase}
+  fi
+  echo
+  
+  echo "---- Shell process limits ----"
+  ulimit -a
+  echo
+  
+  echo "---- Check python version ----"
+  if [[ ${pythonversion} == '3' ]]; then
+    log "python3 selected from cmdline"
+    setup_python3
+    check_python3
+  else
+    log "Default python2 selected from cmdline"
+    check_python2
+  fi
+  echo
+
+  echo "---- Check cvmfs area ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Check cvmfs area due to --container flag'
+  else
+    check_cvmfs
+  fi
+  echo
+
+  echo "---- Setup ALRB ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Setup ALRB due to --container flag'
+  else
+    setup_alrb
+  fi
+  echo
+
+  echo "---- Setup local ATLAS ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Setup local ATLAS due to --container flag'
+  else
+    setup_local
+  fi
+  echo
+
+  echo "---- Setup logstash ----"
+  result=$(get_catchall)
+  if [[ $? -eq 0 ]]; then
+    if grep -q "logging=logstash" <<< "$result"; then
+      log 'Logstash requested via CRIC catchall, running lsetup logstash'
+      lsetup logstash
+      if [[ ${pilotbase} == 'pilot3' && $jarg == 'managed' ]]; then
+        log 'Overriding pilot version pilot3->pilot2 for Paul test'
+      fi
+    else
+      log 'Logstash not requested in CRIC catchall'
+    fi
+  else
+    log 'No content found in CRIC catchall'
+  fi
+  echo
+
+
+  if [[ ${harvesterflag} == 'true' ]]; then
+    echo "---- Create symlinks to input data ----"
+    log 'Create to symlinks to input data from harvester info'
+    setup_harvester_symlinks
+    echo
+  fi
+    
+  if [[ "${shoalflag}" == 'true' ]]; then
+    echo "--- Setup shoal ---"
+    setup_shoal
+    echo
+  fi
+
+  echo "---- Proxy Information ----"
+  if [[ ${tflag} == 'true' ]]; then
+    log 'Skipping proxy checks due to -t flag'
+  else
+    check_proxy
+  fi
+  
+  echo "--- Bespoke environment from CRIC ---"
+  result=$(get_environ)
+  if [[ $? -eq 0 ]]; then
+    if [[ -z ${result} ]]; then
+      log 'CRIC environ field: <empty>'
+    else
+      log 'CRIC environ content'
+      log "export ${result}"
+      export ${result}
+    fi
+  else
+    log 'No content found in CRIC environ'
+  fi
+  echo
+
+  echo "---- Job Environment ----"
+  printenv | sort
+  echo
+  if [[ -n ${ATLAS_LOCAL_AREA} ]]; then
+    log "Content of $ATLAS_LOCAL_AREA/setup.sh.local"
+    cat $ATLAS_LOCAL_AREA/setup.sh.local
+    echo
+  else
+    log "Empty: \$ATLAS_LOCAL_AREA"
+    echo
+  fi
+
+  echo "---- Build pilot cmd ----"
+  cmd=$(pilot_cmd)
+  echo $cmd
+  echo
+
+  echo "---- Ready to run pilot ----"
+  echo
+
+  log "==== pilot stdout BEGIN ===="
+  $cmd &
+  pilotpid=$!
+  wait $pilotpid
+  pilotrc=$?
+  log "==== pilot stdout END ===="
+  log "==== wrapper stdout RESUME ===="
+  log "pilotpid: $pilotpid"
+  log "Pilot exit status: $pilotrc"
+  
+  if [[ -f ${workdir}/${pilotbase}/pandaIDs.out ]]; then
+    # max 30 pandaids
+    pandaids=$(cat ${workdir}/${pilotbase}/pandaIDs.out | xargs echo | cut -d' ' -f-30)
+    log "pandaids: ${pandaids}"
+  else
+    log "File not found: ${workdir}/${pilotbase}/pandaIDs.out, no payload"
+    err "File not found: ${workdir}/${pilotbase}/pandaIDs.out, no payload"
+    pandaids=''
+  fi
+
+  duration=$(( $(date +%s) - ${starttime} ))
+  apfmon_exiting ${pilotrc} ${duration}
+  
+
+  if [[ ${piloturl} != 'local' ]]; then
+      log "cleanup: rm -rf $workdir"
+      rm -fr $workdir
+  else 
+      log "Test setup, not cleaning"
+  fi
+
+  sortie 0
+}
+
+function usage () {
+  echo "Usage: $0 -q <queue> -r <resource> -s <site> [<pilot_args>]"
+  echo
+  echo "  --container (Standalone container), file to source for release setup "
+  echo "  --harvester (Harvester at HPC edge), NodeID from HPC batch system "
+  echo "  -i,   pilot type, default PR"
+  echo "  -j,   job type prodsourcelabel, default 'managed'"
+  echo "  -q,   panda queue"
+  echo "  -r,   panda resource"
+  echo "  -s,   sitename for local setup"
+  echo "  -t,   pass -t option to pilot, skipping proxy check"
+  echo "  -S,   setup shoal client"
+  echo "  --piloturl, URL of pilot code tarball"
+  echo "  --pilotversion, request particular pilot version"
+  echo "  --pythonversion,   valid values '2' (default), and '3'"
+  echo "  --localpy, skip ALRB setup and use local python"
+  echo
+  exit 1
+}
+
+starttime=$(date +%s)
+
+# wrapper args are explicit if used in the wrapper
+# additional pilot2 args are passed as extra args
+containerflag='false'
+containerarg=''
+harvesterflag='false'
+harvesterarg=''
+workflowarg=''
+iarg='PR'
+jarg='managed'
+qarg=''
+rarg=''
+shoalflag='false'
+localpyflag='false'
+tflag='false'
+piloturl=''
+pilotversion='latest'
+pilotbase='pilot2'
+pythonversion='2'
+mute='false'
+myargs="$@"
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    -h|--help)
+    usage
+    shift
+    shift
+    ;;
+    --container)
+    containerflag='true'
+    #containerarg="$2"
+    #shift
+    shift
+    ;;
+    --harvester)
+    harvesterflag='true'
+    harvesterarg="$2"
+    mute='true'
+    piloturl='local'
+    shift
+    shift
+    ;;
+    --harvester_workflow)
+    harvesterflag='true'
+    workflowarg="$2"
+    shift
+    shift
+    ;;
+    --mute)
+    mute='true'
+    shift
+    ;;
+    --pilotversion)
+    pilotversion="$2"
+    shift
+    shift
+    ;;
+    --pythonversion)
+    pythonversion="$2"
+    shift
+    shift
+    ;;
+    --piloturl)
+    piloturl="$2"
+    shift
+    shift
+    ;;
+    -i)
+    iarg="$2"
+    shift
+    shift
+    ;;
+    -j)
+    jarg="$2"
+    shift
+    shift
+    ;;
+    -q)
+    qarg="$2"
+    shift
+    shift
+    ;;
+    -r)
+    rarg="$2"
+    shift
+    shift
+    ;;
+    -s)
+    sarg="$2"
+    shift
+    shift
+    ;;
+    --localpy)
+    localpyflag=true
+    shift
+    ;;
+    -S|--shoal)
+    shoalflag=true
+    shift
+    ;;
+    -t)
+    tflag='true'
+    POSITIONAL+=("$1") # save it in an array for later
+    shift
+    ;;
+    *)
+    POSITIONAL+=("$1") # save it in an array for later
+    shift
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [ -z "${qarg}" ]; then usage; exit 1; fi
+
+pilotargs="$@"
+
+cricurl="https://pandaserver-tb.cern.ch/cache/schedconfig/${sarg}.all.json"
+fabricmon="http://apfmon.lancs.ac.uk/api"
+if [ -z ${APFMON} ]; then
+  APFMON=${fabricmon}
+fi
+
+pilotargs="${pilotargs} --queuedata-url ${cricurl}"
+
+main "$myargs"

--- a/helm/harvester/charts/harvester/sandbox/atlas.submit_pilot.sdf
+++ b/helm/harvester/charts/harvester/sandbox/atlas.submit_pilot.sdf
@@ -1,0 +1,39 @@
+executable = {executableFile}
+arguments = "-s {computingSite} -r {computingSite} -q {pandaQueueName} -j {pilotJobLabel} -i {pilotType} {pilotPythonOption} -w generic --pilot-user ATLAS --url https://pandaserver-tb.cern.ch -d --baseurls https://pandaserver-tb.cern.ch --port 443 {pilotDebugOption} --harvester-submit-mode PUSH {pilotResourceTypeOption} --pilotversion {pilotVersion} {pilotUrlOption} {pilotArgs}"
+initialdir = {accessPoint}
+universe = grid
+log = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).log
+output = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).out
+error = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).err
+transfer_executable = True
+x509userproxy = {x509UserProxy}
+environment = "PANDA_JSID=harvester-{harvesterID} HARVESTER_ID={harvesterID} HARVESTER_WORKER_ID={workerID} GTAG={gtag} APFMON=http://apfmon.lancs.ac.uk/api APFFID={harvesterID} APFCID=$(Cluster).$(Process) PANDA_AUTH_ORIGIN=Rubin.production PANDA_AUTH_TOKEN={pandaTokenFilename} PANDA_AUTH_TOKEN_KEY={pandaTokenKeyFilename}"
+transfer_input_files = pandaJobData.out,{pandaTokenPath},{pandaTokenKeyPath}
+
++harvesterID = "{harvesterID}"
+
+grid_resource = condor {ceHostname} {ceEndpoint}
+
++remote_jobuniverse = 5
++remote_ShouldTransferFiles = "YES"
++remote_WhenToTransferOutput = "ON_EXIT_OR_EVICT"
++remote_TransferOutput = ""
++ioIntensity = 0
++xcount = 1
++maxMemory = 2000
++remote_queue = "share"
++maxWallTime = 4800
+
+delegate_job_GSI_credentials_lifetime = 0
+
+periodic_remove = (JobStatus == 2 && (CurrentTime - EnteredCurrentStatus) > 604800)
++remote_PeriodicRemove = (JobStatus == 5 && (CurrentTime - EnteredCurrentStatus) > 3600) || (JobStatus == 1 && globusstatus =!= 1 && (CurrentTime - EnteredCurrentStatus) > 86400)
+
++ioIntensity = {ioIntensity}
++sdfPath = "{sdfPath}"
++ScitokensFile = "{tokenPath}"
+
++RequireGPUs = False
++RequestGPUs = 0
+
+queue 1

--- a/helm/harvester/charts/harvester/sandbox/bnl_osg.submit_pilot_token_push.sdf
+++ b/helm/harvester/charts/harvester/sandbox/bnl_osg.submit_pilot_token_push.sdf
@@ -1,0 +1,55 @@
+executable = /opt/harvester/sandbox/runpilot2-wrapper-doma.sh
+
+arguments = -s {computingSite} -r {computingSite} -q {pandaQueueName} -j {prodSourceLabel} -i {pilotType} -t -w generic --pilot-user sphenix --url https://pandaserver-doma.cern.ch:443 -d --harvester-submit-mode PUSH --allow-same-user=False --job-type={jobType} {pilotResourceTypeOption} --pilotversion 3 --pythonversion 3
+
+initialdir = {accessPoint}
+
+log = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).log
+output = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).out
+error = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).err
+transfer_executable = True
+
+environment = "PANDA_JSID=harvester-{harvesterID} HARVESTER_ID={harvesterID} HARVESTER_WORKER_ID={workerID} GTAG={gtag} STORAGEDATA_SERVER_URL=https://datalake-cric.cern.ch/api/atlas/ddmendpoint/query/?json PANDA_AUTH_ORIGIN=panda_dev.pilot PANDA_AUTH_TOKEN=c9b4ffca7df17fd45bc0d639bb73cd90 "
++harvesterID = "{harvesterID}"
++harvesterWorkerID = "{workerID}"
+
+transfer_input_files = {accessPoint}/pandaJobData.out,/data/tokens/pilot/c9b4ffca7df17fd45bc0d639bb73cd90
+
+universe = grid
+grid_resource = condor gridgk04.sdcc.bnl.gov gridgk04.sdcc.bnl.gov:9619
+
+X509UserProxy = {x509UserProxy}
+ShouldTransferFiles = YES
+WhenToTransferOutput = ON_EXIT
+use_x509userproxy = true
+
++remote_jobuniverse = 5
++remote_ShouldTransferFiles = "YES"
++remote_WhenToTransferOutput = "ON_EXIT_OR_EVICT"
++remote_TransferOutput = ""
+#+remote_RequestCpus = {nCoreTotal}
+#+remote_RequestMemory = {requestRam}
+#+remote_RequestDisk = {requestDisk}
+#+remote_JobMaxVacateTime = {requestWalltime}
++ioIntensity = {ioIntensity}
++xcount = {nCoreTotal}
++maxMemory = {requestRam}
++remote_queue = "{ceQueueName}"
++maxWallTime = 1440
+
+delegate_job_GSI_credentials_lifetime = 0
+
+#+remote_Requirements = JobRunCount == 0
+periodic_remove = (JobStatus == 2 && (CurrentTime - EnteredCurrentStatus) > 604800)
+#+remote_PeriodicHold = ( JobStatus==1 && gridjobstatus=?=UNDEFINED && CurrentTime-EnteredCurrentStatus>3600 ) || ( (JobRunCount =!= UNDEFINED && JobRunCount > 0) ) || ( JobStatus == 2 && CurrentTime-EnteredCurrentStatus>604800 )
++remote_PeriodicRemove = (JobStatus == 5 && (CurrentTime - EnteredCurrentStatus) > 3600) || (JobStatus == 1 && globusstatus =!= 1 && (CurrentTime - EnteredCurrentStatus) > 86400)
+
++sdfPath = "{sdfPath}"
+# +ScitokensFile = "{tokenPath}"
++ScitokensFile = "/opt/harvester/etc/auth/..data/tmp_gridgk04.racf.bnl.gov_prod.token"
+
++ProjectName="EIC"
+#+remote_queue = "osg"
+
+queue 1
+

--- a/helm/harvester/charts/harvester/sandbox/cnaf_darkside.submit_pilot_token_push.sdf
+++ b/helm/harvester/charts/harvester/sandbox/cnaf_darkside.submit_pilot_token_push.sdf
@@ -1,0 +1,54 @@
+executable = /opt/harvester/sandbox/runpilot2-wrapper-doma.sh
+
+arguments = -s {computingSite} -r {computingSite} -q {pandaQueueName} -j {prodSourceLabel} -i {pilotType} -t -w generic --pilot-user sphenix --url https://pandaserver-doma.cern.ch:443 -d --harvester-submit-mode PUSH --allow-same-user=False --job-type={jobType} {pilotResourceTypeOption} --pilotversion 3 --pythonversion 3
+
+initialdir = {accessPoint}
+
+log = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).log
+output = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).out
+error = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).err
+transfer_executable = True
+
+environment = "PANDA_JSID=harvester-{harvesterID} HARVESTER_ID={harvesterID} HARVESTER_WORKER_ID={workerID} GTAG={gtag} STORAGEDATA_SERVER_URL=https://datalake-cric.cern.ch/api/atlas/ddmendpoint/query/?json"
++harvesterID = "{harvesterID}"
++harvesterWorkerID = "{workerID}"
+
+transfer_input_files = {accessPoint}/pandaJobData.out,/data/tokens/pilot/c9b4ffca7df17fd45bc0d639bb73cd90
+
+universe = grid
+grid_resource = condor ce04-htc.cr.cnaf.infn.it ce04-htc.cr.cnaf.infn.it:9619
+
+X509UserProxy = {x509UserProxy}
+ShouldTransferFiles = YES
+WhenToTransferOutput = ON_EXIT
+use_x509userproxy = true
+
++remote_jobuniverse = 5
++remote_ShouldTransferFiles = "YES"
++remote_WhenToTransferOutput = "ON_EXIT_OR_EVICT"
++remote_TransferOutput = ""
+#+remote_RequestCpus = {nCoreTotal}
+#+remote_RequestMemory = {requestRam}
+#+remote_RequestDisk = {requestDisk}
+#+remote_JobMaxVacateTime = {requestWalltime}
++ioIntensity = {ioIntensity}
++xcount = {nCoreTotal}
++maxMemory = {requestRam}
++remote_queue = "{ceQueueName}"
++maxWallTime = 1440
+
+delegate_job_GSI_credentials_lifetime = 0
+
+#+remote_Requirements = JobRunCount == 0
+periodic_remove = (JobStatus == 2 && (CurrentTime - EnteredCurrentStatus) > 604800)
+#+remote_PeriodicHold = ( JobStatus==1 && gridjobstatus=?=UNDEFINED && CurrentTime-EnteredCurrentStatus>3600 ) || ( (JobRunCount =!= UNDEFINED && JobRunCount > 0) ) || ( JobStatus == 2 && CurrentTime-EnteredCurrentStatus>604800 )
++remote_PeriodicRemove = (JobStatus == 5 && (CurrentTime - EnteredCurrentStatus) > 3600) || (JobStatus == 1 && globusstatus =!= 1 && (CurrentTime - EnteredCurrentStatus) > 86400)
+
++sdfPath = "{sdfPath}"
+# +ScitokensFile = "{tokenPath}"
+
++ProjectName="DarkSide"
+#+remote_queue = "osg"
+
+queue 1
+

--- a/helm/harvester/charts/harvester/sandbox/doma.run-harvester-crons
+++ b/helm/harvester/charts/harvester/sandbox/doma.run-harvester-crons
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# renew vomsproxy
+while true; do bash /opt/harvester/sandbox/doma.vomsproxy-renew; sleep 3600; done &
+

--- a/helm/harvester/charts/harvester/sandbox/doma.vomsproxy-renew
+++ b/helm/harvester/charts/harvester/sandbox/doma.vomsproxy-renew
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+proxy_path=/opt/harvester/etc/auth
+new_proxy_path=/data/harvester/run
+proxy_user=iddssv1
+
+proxy_cert=${proxy_path}/pilot_usercert.pem
+proxy_key=${proxy_path}/pilot_userkey.pem
+
+proxy=${new_proxy_path}/x509up_u25606
+
+cp  $proxy_cert $new_proxy_path
+cp $proxy_key $new_proxy_path
+new_proxy_cert=${new_proxy_path}/pilot_usercert.pem
+new_proxy_key=${new_proxy_path}/pilot_userkey.pem
+chmod 600 $new_proxy_cert
+chmod 600 $new_proxy_key
+
+#voms-proxy-init2 -valid 96:00 -rfc -voms sphenix -q -cert $new_proxy_cert -key $new_proxy_key -out $proxy 
+
+voms-proxy-fake -rfc -voms eic -out /data/harvester/run/x509up_u25606 -hours 96 \
+   -cert=/data/harvester/run/pilot_usercert.pem -key=/data/harvester/run/pilot_userkey.pem \
+   -hostcert /opt/harvester/sandbox/eicvoms.sdcc.bnl.gov.crt \
+   -hostkey /opt/harvester/sandbox/eicvoms.sdcc.bnl.gov.key \
+   -fqan "/eic/Role=pilot/Capability=NULL" \
+   -uri hcvoms.sdcc.bnl.gov:15001
+
+#check lifetime of certificate
+voms-proxy-info2 -exists -hours 11 -file $proxy
+
+if [ $? -ne 0 ]; then
+  echo $proxy expires in 11 hours on `hostname`, Please check| mail -s "[VOMS_PROXY]WARNING : Grid proxy for Rubin k8s expires soon on `hostname`" atlas-adc-idds-k8s@cern.ch
+fi

--- a/helm/harvester/charts/harvester/sandbox/doma.vomsproxy-renew-eic
+++ b/helm/harvester/charts/harvester/sandbox/doma.vomsproxy-renew-eic
@@ -1,0 +1,6 @@
+voms-proxy-fake -rfc -voms eic -out /data/harvester/run/x509up_u25606 -hours 96 \
+   -cert=/data/harvester/run/pilot_usercert.pem -key=/data/harvester/run/pilot_userkey.pem \
+   -hostcert /data/harvester/run/eic_voms/eicvoms.sdcc.bnl.gov.crt \
+   -hostkey /data/harvester/run/eic_voms/eicvoms.sdcc.bnl.gov.key \
+   -fqan "/eic/Role=pilot/Capability=NULL" \
+   -uri hcvoms.sdcc.bnl.gov:15001 

--- a/helm/harvester/charts/harvester/sandbox/runpilot2-wrapper-doma.sh
+++ b/helm/harvester/charts/harvester/sandbox/runpilot2-wrapper-doma.sh
@@ -1,0 +1,1032 @@
+#!/bin/bash
+#
+# pilot2 wrapper used at CERN central pilot factories
+#
+# https://google.github.io/styleguide/shell.xml
+
+VERSION=20220211a-master
+
+function err() {
+  dt=$(date --utc +"%Y-%m-%d %H:%M:%S,%3N [wrapper]")
+  echo "$dt $@" >&2
+}
+
+function log() {
+  dt=$(date --utc +"%Y-%m-%d %H:%M:%S,%3N [wrapper]")
+  echo "$dt $@"
+}
+
+function get_workdir {
+  if [[ ${piloturl} == 'local' && ${harvesterflag} == 'false' ]]; then
+    echo $(pwd)
+    return 0
+  fi
+
+  if [[ ${harvesterflag} == 'true' ]]; then
+    # test if Harvester WorkFlow is OneToMany aka "Jumbo" Jobs
+    if [[ ${workflowarg} == 'OneToMany' ]]; then
+      if [[ -n ${!harvesterarg} ]]; then
+        templ=$(pwd)/atlas_${!harvesterarg}
+        mkdir ${templ}
+        echo ${templ}
+        return 0
+      fi
+    else
+      echo $(pwd)
+      return 0
+    fi
+  fi
+
+  if [[ -n "${OSG_WN_TMP}" ]]; then
+    templ=${OSG_WN_TMP}/atlas_XXXXXXXX
+  elif [[ -n "${TMPDIR}" ]]; then
+    templ=${TMPDIR}/atlas_XXXXXXXX
+  else
+    templ=$(pwd)/atlas_XXXXXXXX
+  fi
+  tempd=$(mktemp -d $templ)
+  echo ${tempd}
+}
+
+function check_python2() {
+  pybin=$(which python2)
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: python2 not found in PATH"
+    err "FATAL: python2 not found in PATH"
+    if [[ -z "${PATH}" ]]; then
+      log "In fact, PATH env var is unset mon amie"
+      err "In fact, PATH env var is unset mon amie"
+    fi
+    log "PATH content is ${PATH}"
+    err "PATH content is ${PATH}"
+    apfmon_fault 1
+    sortie 1
+  fi
+    
+  pyver=$($pybin -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
+  # we don't want python3 if requesting python2 explicitly
+  if [[ ${pyver} -ge 30 ]] ; then
+    log "ERROR: this site has python > 3.0, but only python2 requested"
+    err "ERROR: this site has python > 3.0, but only python2 requested"
+    apfmon_fault 1
+    sortie 1
+  fi
+
+  # check if native python version > 2.6
+  if [[ ${pyver} -ge 26 ]] ; then
+    log "Native python version is > 2.6 (${pyver})"
+    log "Using ${pybin} for python compatibility"
+    return
+  else
+    log "ERROR: this site has native python < 2.6"
+    err "ERROR: this site has native python < 2.6"
+    log "Native python ${pybin} is old: ${pyver}"
+  
+    # Oh dear, we're doomed...
+    log "FATAL: Failed to find a compatible python, exiting"
+    err "FATAL: Failed to find a compatible python, exiting"
+    apfmon_fault 1
+    sortie 1
+  fi
+}
+
+function setup_python3() {
+  # setup python3 from ALRB, default for grid sites
+  if [[ ${localpyflag} == 'true' ]]; then
+    log "localpyflag is true so we skip ALRB python3"
+  elif [[ ${ATLAS_LOCAL_PYTHON} == 'true' ]]; then
+    # email thread 7/7/21 dealing with LRZ SUSE
+    log "Env var ATLAS_LOCAL_PYTHON=true so skip ALRB python3"
+  else
+    log "Using ALRB to setup python3"
+    if [ -z "$ATLAS_LOCAL_ROOT_BASE" ]; then
+        export ATLAS_LOCAL_ROOT_BASE="/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase"
+    fi
+    export ALRB_LOCAL_PY3="YES"
+    source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh --quiet
+    lsetup -q "python pilot-default" 
+  fi
+}
+
+function check_python3() {
+  pybin=$(which python3)
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: python3 not found in PATH"
+    err "FATAL: python3 not found in PATH"
+    if [[ -z "${PATH}" ]]; then
+      log "In fact, PATH env var is unset mon amie"
+      err "In fact, PATH env var is unset mon amie"
+    fi
+    log "PATH content: ${PATH}"
+    err "PATH content: ${PATH}"
+    apfmon_fault 1
+    sortie 1
+  fi
+    
+  pyver=$($pybin -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
+  # check if python version > 3.6
+  if [[ ${pyver} -ge 36 ]] ; then
+    log "Python version is > 3.6 (${pyver})"
+    log "Using ${pybin} for python compatibility"
+  else
+    log "ERROR: this site has python < 3.6"
+    err "ERROR: this site has python < 3.6"
+    log "Python ${pybin} is old: ${pyver}"
+  
+    # Oh dear, we're doomed...
+    log "FATAL: Failed to find a compatible python, exiting"
+    err "FATAL: Failed to find a compatible python, exiting"
+    apfmon_fault 1
+    sortie 1
+  fi
+}
+
+function check_proxy() {
+  voms-proxy-info -all
+  if [[ $? -ne 0 ]]; then
+    log "WARNING: error running: voms-proxy-info -all"
+    err "WARNING: error running: voms-proxy-info -all"
+    arcproxy -I
+    if [[ $? -eq 127 ]]; then
+      log "FATAL: error running: arcproxy -I"
+      err "FATAL: error running: arcproxy -I"
+      apfmon_fault 1
+      sortie 1
+    fi
+  fi
+}
+
+function check_cvmfs() {
+  export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-/cvmfs/atlas.cern.ch/repo/sw}
+  if [[ -d ${VO_ATLAS_SW_DIR} ]]; then
+    log "Found atlas software repository: ${VO_ATLAS_SW_DIR}"
+  else
+    log "ERROR: atlas software repository NOT found: ${VO_ATLAS_SW_DIR}"
+    log "FATAL: Failed to find atlas software repository"
+    err "FATAL: Failed to find atlas software repository"
+    apfmon_fault 1
+    sortie 1
+  fi
+}
+  
+function setup_alrb() {
+  log 'NOTE: rucio,davix,xrootd setup now done in local site setup atlasLocalSetup.sh'
+  if [[ ${iarg} == "RC" ]]; then
+    log 'RC pilot requested, setting ALRB_rucioVersion=testing'
+    export ALRB_rucioVersion=testing
+  fi
+  if [[ ${iarg} == "ALRB" ]]; then
+    log 'ALRB pilot requested, setting ALRB env vars to testing'
+    export ALRB_adcTesting=YES
+  fi
+  export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase}
+  export ALRB_userMenuFmtSkip=YES
+  export ALRB_noGridMW=${ALRB_noGridMW:-NO}
+
+  if [[ ${ALRB_noGridMW} == "YES" ]]; then
+    log "Site has set ALRB_noGridMW=YES so use site native install rather than ALRB"
+    if [[ ${tflag} == 'true' ]]; then
+      log 'Skipping proxy checks due to -t flag'
+    else
+      check_vomsproxyinfo || check_arcproxy
+      if [[ $? -eq 1 ]]; then
+        log "FATAL: Site MW being used but proxy tools not found"
+        err "FATAL: Site MW being used but proxy tools not found"
+        apfmon_fault 1
+        sortie 1
+      fi
+    fi
+  else
+    log "Will use ALRB MW because ALRB_noGridMW=NO (default)"
+  fi
+
+}
+
+function setup_local() {
+  log "Looking for ${VO_ATLAS_SW_DIR}/local/setup.sh"
+  if [[ -f ${VO_ATLAS_SW_DIR}/local/setup.sh ]]; then
+    if [[ ${pythonversion} == '3' ]]; then
+      log "Sourcing ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg} -p python3"
+      source ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg} -p python3
+    else
+      log "Sourcing ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg}"
+      source ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg}
+    fi
+  else
+    log 'WARNING: No ATLAS local setup found'
+    err 'WARNING: this site has no local setup ${VO_ATLAS_SW_DIR}/local/setup.sh'
+  fi
+  # OSG MW setup, skip if not using ALRB Grid MW
+  if [[ ${ALRB_noGridMW} == "YES" ]]; then
+    if [[ -f ${OSG_GRID}/setup.sh ]]; then
+      log "Setting up OSG MW using ${OSG_GRID}/setup.sh"
+      source ${OSG_GRID}/setup.sh
+    else
+      log 'Env var ALRB_noGridMW=NO, not sourcing ${OSG_GRID}/setup.sh'
+    fi
+  fi
+
+}
+
+function setup_shoal() {
+  log "will set FRONTIER_SERVER with shoal"
+
+  outputstr=$(env -i FRONTIER_SERVER="$FRONTIER_SERVER"  /bin/bash -l -c "shoal-client -f")
+  if [[ $? -eq 0 ]] &&  [[ -n "${outputstr}" ]] ; then
+    export FRONTIER_SERVER=${outputstr}
+  else
+    log "WARNING: shoal-client had non-zero exit code or empty output"
+  fi
+
+  log "FRONTIER_SERVER = $FRONTIER_SERVER"
+}
+
+function setup_harvester_symlinks() {
+  for datafile in `find ${HARVESTER_WORKDIR} -maxdepth 1 -type l -exec /usr/bin/readlink -e {} ';'`; do
+      symlinkname=$(basename $datafile)
+      ln -s $datafile $symlinkname
+  done      
+}
+
+
+function check_vomsproxyinfo() {
+  out=$(voms-proxy-info --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Check version: ${out}"
+    return 0
+  else
+    log "voms-proxy-info not found"
+    return 1
+  fi
+}
+
+function check_arcproxy() {
+  out=$(arcproxy --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Check version: ${out}"
+    return 0
+  else
+    log "arcproxy not found"
+    return 1
+  fi
+}
+
+function pilot_cmd() {
+
+  # test if not harvester job 
+  if [[ ${harvesterflag} == 'false' ]] ; then  
+    if [[ -n ${pilotversion} ]]; then
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} --pilot-user=ATLAS ${pilotargs}"
+    else
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} --pilot-user=ATLAS ${pilotargs}"
+    fi
+  else
+    # check to see if we are running OneToMany Harvester workflow (aka Jumbo Jobs)
+    if [[ ${workflowarg} == 'OneToMany' ]] && [ -z ${HARVESTER_PILOT_WORKDIR+x} ] ; then
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} -a ${HARVESTER_PILOT_WORKDIR} --pilot-user=ATLAS ${pilotargs}"
+    else
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} --pilot-user=ATLAS ${pilotargs}"
+    fi
+  fi
+  echo ${cmd}
+}
+
+function sing_cmd() {
+  cmd="$BINARY_PATH exec $SINGULARITY_OPTIONS $IMAGE_PATH $0 $myargs"
+  echo ${cmd}
+}
+
+function sing_env() {
+  export SINGULARITYENV_X509_USER_PROXY=${X509_USER_PROXY}
+  if [[ -n "${ATLAS_LOCAL_AREA}" ]]; then
+    export SINGULARITYENV_ATLAS_LOCAL_AREA=${ATLAS_LOCAL_AREA}
+  fi
+  if [[ -n "${TMPDIR}" ]]; then
+    export SINGULARITYENV_TMPDIR=${TMPDIR}
+  fi
+  if [[ -n "${RECOVERY_DIR}" ]]; then
+    export SINGULARITYENV_RECOVERY_DIR=${RECOVERY_DIR}
+  fi
+}
+
+function get_piloturl() {
+  local version=$1
+  local pilotdir=file:///cvmfs/atlas.cern.ch/repo/sw/PandaPilot/tar
+
+  if [[ -n ${piloturl} ]]; then
+    echo ${piloturl}
+    return 0
+  fi
+
+  if [[ ${version} == '1' ]]; then
+    log "FATAL: pilot version 1 requested, not supported by this wrapper"
+    err "FATAL: pilot version 1 requested, not supported by this wrapper"
+    apfmon 1
+    sortie 1
+  elif [[ ${version} == '2' ]]; then
+    pilottar=${pilotdir}/pilot2.tar.gz
+  elif [[ ${version} == 'latest' ]]; then
+    pilottar=${pilotdir}/pilot2.tar.gz
+  elif [[ ${version} == 'current' ]]; then
+    pilottar=${pilotdir}/pilot2.tar.gz
+  elif [[ ${version} == '3' ]]; then
+    pilottar=${pilotdir}/pilot3.tar.gz
+    pilotbase='pilot3'
+  else
+    pilottar=${pilotdir}/pilot2-${version}.tar.gz
+  fi
+  echo ${pilottar}
+}
+
+function get_pilot() {
+
+  local url=$1
+
+  if [[ ${harvesterflag} == 'true' ]] && [[ ${workflowarg} == 'OneToMany' ]]; then
+    cp -v ${HARVESTER_WORK_DIR}/pilot2.tar.gz .
+  fi
+
+  if [[ ${url} == 'local' ]]; then
+    log "piloturl=local so download not needed"
+    
+    if [[ -f pilot2.tar.gz ]]; then
+      log "local tarball pilot2.tar.gz exists OK"
+      tar -xzf pilot2.tar.gz
+      if [[ $? -ne 0 ]]; then
+        log "ERROR: pilot extraction failed for pilot2.tar.gz"
+        err "ERROR: pilot extraction failed for pilot2.tar.gz"
+        return 1
+      fi
+    elif [[ -f pilot3.tar.gz ]]; then
+      log "local tarball pilot3.tar.gz exists OK"
+      tar -xzf pilot3.tar.gz
+      if [[ $? -ne 0 ]]; then
+        log "ERROR: pilot extraction failed for pilot3.tar.gz"
+        err "ERROR: pilot extraction failed for pilot3.tar.gz"
+        return 1
+      fi
+    else
+      log "local pilot[23].tar.gz not found so assuming already extracted"
+    fi
+  else
+    curl --connect-timeout 30 --max-time 180 -sSL ${url} | tar -xzf -
+    if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+      log "ERROR: pilot download failed: ${url}"
+      err "ERROR: pilot download failed: ${url}"
+      return 1
+    fi
+  fi
+
+  if [[ -f ${pilotbase}/pilot.py ]]; then
+    log "File ${pilotbase}/pilot.py exists OK"
+    log "${pilotbase}/PILOTVERSION: $(cat ${pilotbase}/PILOTVERSION)"
+    return 0
+  else
+    log "ERROR: ${pilotbase}/pilot.py not found"
+    err "ERROR: ${pilotbase}/pilot.py not found"
+    return 1
+  fi
+}
+
+function muted() {
+  log "apfmon messages muted"
+}
+
+function apfmon_running() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+  echo -n "running 0 ${VERSION} ${qarg} ${APFFID}:${APFCID}" > /dev/udp/148.88.67.14/28527
+  resource=${GRID_GLOBAL_JOBHOST:-}
+  out=$(curl -ksS --connect-timeout 10 --max-time 20 -d uuid=${UUID} \
+             -d qarg=${qarg} -d state=wrapperrunning -d wrapper=${VERSION} \
+             -d gtag=${GTAG} -d resource=${resource} \
+             -d hid=${HARVESTER_ID} -d hwid=${HARVESTER_WORKER_ID} \
+             ${APFMON}/jobs/${APFFID}:${APFCID})
+  if [[ $? -eq 0 ]]; then
+    log $out
+  else
+    err "WARNING: wrapper monitor ${UUID}"
+  fi
+}
+
+function apfmon_exiting() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+  out=$(curl -ksS --connect-timeout 10 --max-time 20 \
+             -d state=wrapperexiting -d rc=$1 -d uuid=${UUID} \
+             -d ids="${pandaids}" -d duration=$2 \
+             ${APFMON}/jobs/${APFFID}:${APFCID})
+  if [[ $? -eq 0 ]]; then
+    log $out
+  else
+    err "WARNING: wrapper monitor ${UUID}"
+  fi
+}
+
+function apfmon_fault() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+
+  out=$(curl -ksS --connect-timeout 10 --max-time 20 \
+             -d state=wrapperfault -d rc=$1 -d uuid=${UUID} \
+             ${APFMON}/jobs/${APFFID}:${APFCID})
+  if [[ $? -eq 0 ]]; then
+    log $out
+  else
+    err "WARNING: wrapper monitor ${UUID}"
+  fi
+}
+
+function trap_handler() {
+  if [[ -n "${pilotpid}" ]]; then
+    log "WARNING: Caught $1, signalling pilot PID: $pilotpid"
+    kill -s $1 $pilotpid
+    wait
+  else
+    log "WARNING: Caught $1 prior to pilot starting"
+  fi
+}
+
+function sortie() {
+  ec=$1
+  if [[ $ec -eq 0 ]]; then
+    state=wrapperexiting
+  else
+    state=wrapperfault
+  fi
+
+  log "==== wrapper stdout END ===="
+  err "==== wrapper stderr END ===="
+
+  duration=$(( $(date +%s) - ${starttime} ))
+  log "${state} ec=$ec, duration=${duration}"
+  
+  if [[ ${mute} == 'true' ]]; then
+    muted
+  else
+    echo -n "${state} ${duration} ${VERSION} ${qarg} ${APFFID}:${APFCID}" > /dev/udp/148.88.67.14/28527
+  fi
+
+  exit $ec
+}
+
+function get_cricopts() {
+  container_opts=$(curl --silent $cricurl | grep container_options | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    cricopts=$(echo $container_opts | awk -F"\"" '{print $4}')
+    echo ${cricopts}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_catchall() {
+  local result
+  local content
+  result=$(curl --silent $cricurl | grep catchall | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    content=$(echo $result | awk -F"\"" '{print $4}')
+    echo ${content}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_environ() {
+  local result
+  local content
+  result=$(curl --silent $cricurl | grep environ | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    content=$(echo $result | awk -F"\"" '{print $4}')
+    echo ${content}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function check_singularity() {
+  BINARY_PATH="/cvmfs/atlas.cern.ch/repo/containers/sw/singularity/`uname -m`-el7/current/bin/singularity"
+  IMAGE_PATH="/cvmfs/atlas.cern.ch/repo/containers/fs/singularity/`uname -m`-centos7"
+  SINGULARITY_OPTIONS="$(get_cricopts) -B /cvmfs -B $PWD --cleanenv"
+  out=$(${BINARY_PATH} --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Singularity binary found, version $out"
+    log "Singularity binary path: ${BINARY_PATH}"
+  else
+    log "Singularity binary not found"
+  fi
+}
+
+function check_type() {
+  if [[ -f queuedata.json ]]; then
+    result=$(cat queuedata.json | grep container_type | grep 'singularity:wrapper')
+  else
+    result=$(curl --silent $cricurl | grep container_type | grep 'singularity:wrapper')
+  fi
+  if [[ $? -eq 0 ]]; then
+    log "CRIC container_type: singularity:wrapper found"
+    return 0
+  else
+    log "CRIC container_type: singularity:wrapper not found"
+    return 1
+  fi
+}
+
+
+function main() {
+  #
+  # Fail early, fail often^W with useful diagnostics
+  #
+  trap 'trap_handler SIGINT' SIGINT
+  trap 'trap_handler SIGTERM' SIGTERM
+  trap 'trap_handler SIGQUIT' SIGQUIT
+  trap 'trap_handler SIGSEGV' SIGSEGV
+  trap 'trap_handler SIGXCPU' SIGXCPU
+  trap 'trap_handler SIGUSR1' SIGUSR1
+  trap 'trap_handler SIGUSR2' SIGUSR2
+  trap 'trap_handler SIGBUS' SIGBUS
+
+  if [[ -z ${SINGULARITY_ENVIRONMENT} ]]; then
+    # SINGULARITY_ENVIRONMENT not set
+    echo "This is ATLAS pilot wrapper version: $VERSION"
+    echo "Please send development requests to p.love@lancaster.ac.uk"
+    echo
+    log "==== wrapper stdout BEGIN ===="
+    err "==== wrapper stderr BEGIN ===="
+    UUID=$(cat /proc/sys/kernel/random/uuid)
+    apfmon_running
+    log "${cricurl}"
+    echo
+    echo "---- Initial environment ----"
+    printenv | sort
+    echo
+    echo "---- PWD content ----"
+    pwd
+    ls -la
+    echo
+
+    echo "---- Check singularity details (development) ----"
+    cric_opts=$(get_cricopts)
+    if [[ $? -eq 0 ]]; then
+      log "CRIC container_options: $cric_opts"
+    else
+      log "WARNING: failed to get CRIC container_options"
+    fi
+
+    check_type
+    if [[ $? -eq 0 ]]; then
+      use_singularity=true
+      log "container_type contains singularity:wrapper, so use_singularity=true"
+    else
+      use_singularity=false
+    fi
+
+    if [[ ${use_singularity} = true ]]; then
+      # check if already in SINGULARITY environment
+      log 'SINGULARITY_ENVIRONMENT is not set'
+      sing_env
+      log 'Setting SINGULARITY_env'
+      check_singularity
+      export ALRB_noGridMW=NO
+      echo '   _____ _                   __           _ __        '
+      echo '  / ___/(_)___  ____ ___  __/ /___ ______(_) /___  __ '
+      echo '  \__ \/ / __ \/ __ `/ / / / / __ `/ ___/ / __/ / / / '
+      echo ' ___/ / / / / / /_/ / /_/ / / /_/ / /  / / /_/ /_/ /  '
+      echo '/____/_/_/ /_/\__, /\__,_/_/\__,_/_/  /_/\__/\__, /   '
+      echo '             /____/                         /____/    '
+      echo
+      cmd=$(sing_cmd)
+      echo "cmd: $cmd"
+      echo
+      log '==== singularity stdout BEGIN ===='
+      err '==== singularity stderr BEGIN ===='
+      $cmd &
+      singpid=$!
+      wait $singpid
+      log "singularity return code: $?"
+      log '==== singularity stdout END ===='
+      err '==== singularity stderr END ===='
+      log "==== wrapper stdout END ===="
+      err "==== wrapper stderr END ===="
+      exit 0
+    else
+      log 'Will NOT use singularity, at least not from the wrapper'
+    fi
+    echo
+  else
+    log 'SINGULARITY_ENVIRONMENT is set, run basic setup'
+    export ALRB_noGridMW=NO
+    df -h
+  fi
+
+  echo "---- Host details ----"
+  echo "hostname:" $(hostname -f)
+  echo "pwd:" $(pwd)
+  echo "whoami:" $(whoami)
+  echo "id:" $(id)
+  echo "getopt:" $(getopt -V 2>/dev/null)
+  echo "jq:" $(jq --version 2>/dev/null)
+  if [[ -r /proc/version ]]; then
+    echo "/proc/version:" $(cat /proc/version)
+  fi
+  echo "lsb_release:" $(lsb_release -d 2>/dev/null)
+  echo "SINGULARITY_ENVIRONMENT:" ${SINGULARITY_ENVIRONMENT}
+  
+  myargs=$@
+  echo "wrapper call: $0 $myargs"
+
+  cpuinfo_flags="flags: EMPTY"
+  if [ -f /proc/cpuinfo ]; then
+    cpuinfo_flags="$(grep '^flags' /proc/cpuinfo 2>/dev/null | sort -u 2>/dev/null)"
+    if [ -z "${cpuinfo_flags}" ]; then 
+      cpuinfo_flags="flags: EMPTY"
+    fi
+  else
+    cpuinfo_flags="flags: EMPTY"
+  fi
+  
+  echo "Flags from /proc/cpuinfo:"
+  echo ${cpuinfo_flags}
+  echo
+
+  
+  echo "---- Enter workdir ----"
+  echo "PAL TMPDIR: $TMPDIR"
+  echo "PAL ${TMPDIR}/atlas_XXXXXXXX"
+  echo "PAL mktemp: " $(mktemp -d ${TMPDIR}/atlas_XXXXXXXX)
+  mktemp -d ${TMPDIR}/atlas_XXXXXXXX
+  echo MKTEMP: $?
+  workdir=$(get_workdir)
+  log "Workdir: ${workdir}"
+  if [[ -f pandaJobData.out ]]; then
+    log "Copying job description to working dir"
+    cp pandaJobData.out $workdir/pandaJobData.out
+  fi
+  log "cd ${workdir}"
+  cd ${workdir}
+  if [[ ${harvesterflag} == 'true' ]]; then
+        export HARVESTER_PILOT_WORKDIR=${workdir}
+        log "Define HARVESTER_PILOT_WORKDIR : ${HARVESTER_PILOT_WORKDIR}"
+  fi
+  echo
+  
+  echo "---- Retrieve pilot code ----"
+  piloturl=$(get_piloturl ${pilotversion})
+  log "Using piloturl: ${piloturl}"
+
+  if grep -q "pilot3" <<< "$piloturl"; then
+    log "Pilot URL contains pilot3"
+    pilotbase='pilot3'
+  fi
+
+  if [[ ${pilotversion} == '3' ]]; then
+    log "Setting base to pilot3 since cmd line has pilotversion=3"
+    pilotbase='pilot3'
+  fi
+  echo
+
+  echo "---- Logstash overrides (devel Paul) ----"
+  result=$(get_catchall)
+  if [[ $? -eq 0 ]]; then
+    if grep -q "logging=logstash" <<< "$result"; then
+      if [[ ${pilotbase} == 'pilot3' && $jarg == 'managed' ]]; then
+        log 'WARNING: overriding pilot version pilot3->pilot2 for Paul test'
+        pilotbase='pilot2'
+        piloturl='file:///cvmfs/atlas.cern.ch/repo/sw/PandaPilot/tar/pilot2/pilot2.tar.gz'
+      fi
+    else
+      log 'Logstash not requested in CRIC catchall'
+    fi
+  else
+    log 'No content found in CRIC catchall'
+  fi
+  echo
+
+  get_pilot ${piloturl}
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: failed to get pilot code"
+    err "FATAL: failed to get pilot code"
+    apfmon_fault 1
+    sortie 1
+  fi
+  echo
+  
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping defining VO_ATLAS_SW_DIR due to --container flag'
+    log 'Skipping defining ATLAS_LOCAL_ROOT_BASE due to --container flag'
+  else
+    export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-/cvmfs/atlas.cern.ch/repo/sw}
+    export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase}
+  fi
+  echo
+  
+  echo "---- Shell process limits ----"
+  ulimit -a
+  echo
+  
+  echo "---- Check python version ----"
+  if [[ ${pythonversion} == '3' ]]; then
+    log "python3 selected from cmdline"
+    setup_python3
+    check_python3
+  else
+    log "Default python2 selected from cmdline"
+    check_python2
+  fi
+  echo
+
+  echo "---- Check cvmfs area ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Check cvmfs area due to --container flag'
+  else
+    check_cvmfs
+  fi
+  echo
+
+  echo "---- Setup ALRB ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Setup ALRB due to --container flag'
+  else
+    setup_alrb
+  fi
+  echo
+
+  echo "---- Setup local ATLAS ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Setup local ATLAS due to --container flag'
+  else
+    setup_local
+  fi
+  echo
+
+  echo "---- Setup logstash ----"
+  result=$(get_catchall)
+  if [[ $? -eq 0 ]]; then
+    if grep -q "logging=logstash" <<< "$result"; then
+      log 'Logstash requested via CRIC catchall, running lsetup logstash'
+      lsetup logstash
+      if [[ ${pilotbase} == 'pilot3' && $jarg == 'managed' ]]; then
+        log 'Overriding pilot version pilot3->pilot2 for Paul test'
+      fi
+    else
+      log 'Logstash not requested in CRIC catchall'
+    fi
+  else
+    log 'No content found in CRIC catchall'
+  fi
+  echo
+
+  echo "---- Setup stomp ----"
+  result=$(get_catchall)
+  if [[ $? -eq 0 ]]; then
+    if grep -q "messaging=stomp" <<< "$result"; then
+      log 'Stomp requested via CRIC catchall, running lsetup stomp'
+      lsetup stomp
+    else
+      log 'Stomp not requested in CRIC catchall'
+    fi
+  else
+    log 'No content found in CRIC catchall'
+  fi
+  echo
+
+  if [[ ${harvesterflag} == 'true' ]]; then
+    echo "---- Create symlinks to input data ----"
+    log 'Create to symlinks to input data from harvester info'
+    setup_harvester_symlinks
+    echo
+  fi
+    
+  if [[ "${shoalflag}" == 'true' ]]; then
+    echo "--- Setup shoal ---"
+    setup_shoal
+    echo
+  fi
+
+  echo "---- Proxy Information ----"
+  if [[ ${tflag} == 'true' ]]; then
+    log 'Skipping proxy checks due to -t flag'
+  else
+    check_proxy
+  fi
+  
+  echo "--- Bespoke environment from CRIC ---"
+  result=$(get_environ)
+  if [[ $? -eq 0 ]]; then
+    if [[ -z ${result} ]]; then
+      log 'CRIC environ field: <empty>'
+    else
+      log 'CRIC environ content'
+      log "export ${result}"
+      export ${result}
+    fi
+  else
+    log 'No content found in CRIC environ'
+  fi
+  echo
+
+  echo "---- Job Environment ----"
+  printenv | sort
+  echo
+  if [[ -n ${ATLAS_LOCAL_AREA} ]]; then
+    log "Content of $ATLAS_LOCAL_AREA/setup.sh.local"
+    cat $ATLAS_LOCAL_AREA/setup.sh.local
+    echo
+  else
+    log "Empty: \$ATLAS_LOCAL_AREA"
+    echo
+  fi
+
+  echo "---- Build pilot cmd ----"
+  cmd=$(pilot_cmd)
+  echo $cmd
+  echo
+
+  echo "---- Ready to run pilot ----"
+  echo
+
+  log "==== pilot stdout BEGIN ===="
+  $cmd &
+  pilotpid=$!
+  wait $pilotpid
+  pilotrc=$?
+  log "==== pilot stdout END ===="
+  log "==== wrapper stdout RESUME ===="
+  log "pilotpid: $pilotpid"
+  log "Pilot exit status: $pilotrc"
+  
+  if [[ -f ${workdir}/${pilotbase}/pandaIDs.out ]]; then
+    # max 30 pandaids
+    pandaids=$(cat ${workdir}/${pilotbase}/pandaIDs.out | xargs echo | cut -d' ' -f-30)
+    log "pandaids: ${pandaids}"
+  else
+    log "File not found: ${workdir}/${pilotbase}/pandaIDs.out, no payload"
+    err "File not found: ${workdir}/${pilotbase}/pandaIDs.out, no payload"
+    pandaids=''
+  fi
+
+  duration=$(( $(date +%s) - ${starttime} ))
+  apfmon_exiting ${pilotrc} ${duration}
+  
+
+  if [[ ${piloturl} != 'local' ]]; then
+      log "cleanup: rm -rf $workdir"
+      rm -fr $workdir
+  else 
+      log "Test setup, not cleaning"
+  fi
+
+  sortie 0
+}
+
+function usage () {
+  echo "Usage: $0 -q <queue> -r <resource> -s <site> [<pilot_args>]"
+  echo
+  echo "  --container (Standalone container), file to source for release setup "
+  echo "  --harvester (Harvester at HPC edge), NodeID from HPC batch system "
+  echo "  -i,   pilot type, default PR"
+  echo "  -j,   job type prodsourcelabel, default 'managed'"
+  echo "  -q,   panda queue"
+  echo "  -r,   panda resource"
+  echo "  -s,   sitename for local setup"
+  echo "  -t,   pass -t option to pilot, skipping proxy check"
+  echo "  -S,   setup shoal client"
+  echo "  --piloturl, URL of pilot code tarball"
+  echo "  --pilotversion, request particular pilot version"
+  echo "  --pythonversion,   valid values '2' (default), and '3'"
+  echo "  --localpy, skip ALRB setup and use local python"
+  echo
+  exit 1
+}
+
+starttime=$(date +%s)
+
+# wrapper args are explicit if used in the wrapper
+# additional pilot2 args are passed as extra args
+containerflag='false'
+containerarg=''
+harvesterflag='false'
+harvesterarg=''
+workflowarg=''
+iarg='PR'
+jarg='managed'
+qarg=''
+rarg=''
+shoalflag='false'
+localpyflag='false'
+tflag='false'
+piloturl=''
+pilotversion='latest'
+pilotbase='pilot2'
+pythonversion='2'
+mute='false'
+myargs="$@"
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    -h|--help)
+    usage
+    shift
+    shift
+    ;;
+    --container)
+    containerflag='true'
+    #containerarg="$2"
+    #shift
+    shift
+    ;;
+    --harvester)
+    harvesterflag='true'
+    harvesterarg="$2"
+    mute='true'
+    piloturl='local'
+    shift
+    shift
+    ;;
+    --harvester_workflow)
+    harvesterflag='true'
+    workflowarg="$2"
+    shift
+    shift
+    ;;
+    --mute)
+    mute='true'
+    shift
+    ;;
+    --pilotversion)
+    pilotversion="$2"
+    shift
+    shift
+    ;;
+    --pythonversion)
+    pythonversion="$2"
+    shift
+    shift
+    ;;
+    --piloturl)
+    piloturl="$2"
+    shift
+    shift
+    ;;
+    -i)
+    iarg="$2"
+    shift
+    shift
+    ;;
+    -j)
+    jarg="$2"
+    shift
+    shift
+    ;;
+    -q)
+    qarg="$2"
+    shift
+    shift
+    ;;
+    -r)
+    rarg="$2"
+    shift
+    shift
+    ;;
+    -s)
+    sarg="$2"
+    shift
+    shift
+    ;;
+    --localpy)
+    localpyflag=true
+    shift
+    ;;
+    -S|--shoal)
+    shoalflag=true
+    shift
+    ;;
+    -t)
+    tflag='true'
+    POSITIONAL+=("$1") # save it in an array for later
+    shift
+    ;;
+    *)
+    POSITIONAL+=("$1") # save it in an array for later
+    shift
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [ -z "${qarg}" ]; then usage; exit 1; fi
+
+pilotargs="$@"
+
+cricurl="https://pandaserver-doma.cern.ch/cache/schedconfig/${sarg}.all.json"
+fabricmon="http://apfmon.lancs.ac.uk/api"
+if [ -z ${APFMON} ]; then
+  APFMON=${fabricmon}
+fi
+
+pilotargs="${pilotargs} --queuedata-url ${cricurl}"
+
+main "$myargs"

--- a/helm/harvester/charts/harvester/sandbox/runpilot2-wrapper.sh
+++ b/helm/harvester/charts/harvester/sandbox/runpilot2-wrapper.sh
@@ -1,0 +1,1258 @@
+#!/bin/bash
+#
+# pilot wrapper used at CERN central pilot factories
+#
+# https://google.github.io/styleguide/shell.xml
+
+VERSION=20250611a-master
+
+function err() {
+  dt=$(date --utc +"%Y-%m-%d %H:%M:%S,%3N [wrapper]")
+  echo "$dt $@" >&2
+}
+
+function log() {
+  dt=$(date --utc +"%Y-%m-%d %H:%M:%S,%3N [wrapper]")
+  echo "$dt $@"
+}
+
+function sortie() {
+  # Currently Harvester interprets exit-codes as following:
+  #         1: "wrapper fault",
+  #         2: "wrapper killed stuck pilot",
+  #        64: "wrapper got cvmfs repos issue",
+  ec=$1
+
+  if [[ -n "${SUPERVISOR_PID}" ]]; then
+    CHILD=$(ps -o pid= --ppid "$SUPERVISOR_PID")
+  else
+    log "No supervise_pilot process found"
+  fi
+  if [[ -n "${CHILD}" ]]; then
+    log "cleanup supervisor_pilot $CHILD $SUPERVISOR_PID"
+  else
+    log "No supervise_pilot CHILD process found"
+  fi
+  kill -s 15 $CHILD $SUPERVISOR_PID > /dev/null 2>&1
+
+  if [[ ${piloturl} != 'local' ]]; then
+    log "cleanup: rm -rf $workdir"
+    rm -fr $workdir
+  else
+    log "Test setup, not cleaning"
+  fi
+
+  if [[ $ec -eq 0 ]]; then
+    apfmon_exiting ${ec}
+  else
+    apfmon_fault ${ec}
+  fi
+
+  log "==== wrapper stdout END ===="
+  err "==== wrapper stderr END ===="
+
+  exit $ec
+}
+
+function get_workdir {
+  if [[ ${piloturl} == 'local' && ${harvesterflag} == 'false' ]]; then
+    echo $(pwd)
+    return 0
+  fi
+
+  if [[ ${harvesterflag} == 'true' ]]; then
+    # test if Harvester WorkFlow is OneToMany aka "Jumbo" Jobs
+    if [[ ${workflowarg} == 'OneToMany' ]]; then
+      if [[ -n ${!harvesterarg} ]]; then
+        templ=$(pwd)/atlas_${!harvesterarg}
+        mkdir ${templ}
+        echo ${templ}
+        return 0
+      fi
+    else
+      echo $(pwd)
+      return 0
+    fi
+  fi
+
+  if [[ -n "${OSG_WN_TMP}" ]]; then
+    templ=${OSG_WN_TMP}/atlas_XXXXXXXX
+  elif [[ -n "${TMPDIR}" ]]; then
+    templ=${TMPDIR}/atlas_XXXXXXXX
+  else
+    templ=$(pwd)/atlas_XXXXXXXX
+  fi
+  tempd=$(mktemp -d $templ)
+  if [[ $? -ne 0 ]]; then
+    log "ERROR: mktemp failed: $templ"
+    err "ERROR: mktemp failed: $templ"
+    return 1
+  fi
+  echo ${tempd}
+}
+
+function check_python2() {
+  pybin=$(which python2)
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: python2 not found in PATH"
+    err "FATAL: python2 not found in PATH"
+    if [[ -z "${PATH}" ]]; then
+      log "In fact, PATH env var is unset mon amie"
+      err "In fact, PATH env var is unset mon amie"
+    fi
+    log "PATH content is ${PATH}"
+    err "PATH content is ${PATH}"
+    sortie 1
+  fi
+
+  pyver=$($pybin -c 'import sys; print("%i%02i" % (sys.version_info.major, sys.version_info.minor))')
+  # we don't want python3 if requesting python2 explicitly
+  if [[ ${pyver} -ge 300 ]] ; then
+    log "ERROR: this site has python > 3.0, but only python2 requested"
+    err "ERROR: this site has python > 3.0, but only python2 requested"
+    sortie 1
+  fi
+
+  # check if native python version > 2.6
+  if [[ ${pyver} -ge 206 ]] ; then
+    log "Native python version is > 2.6 (${pyver})"
+    log "Using ${pybin} for python compatibility"
+    return
+  else
+    log "ERROR: this site has native python < 2.6"
+    err "ERROR: this site has native python < 2.6"
+    log "Native python ${pybin} is old: ${pyver}"
+
+    # Oh dear, we're doomed...
+    log "FATAL: Failed to find a compatible python, exiting"
+    err "FATAL: Failed to find a compatible python, exiting"
+    sortie 1
+  fi
+}
+
+function setup_python3() {
+  # setup python3 from ALRB, default for grid sites
+  if [[ ${localpyflag} == 'true' ]]; then
+    log "localpyflag is true so we skip ALRB python3"
+  elif [[ ${ATLAS_LOCAL_PYTHON} == 'true' ]]; then
+    # email thread 7/7/21 dealing with LRZ SUSE
+    log "Env var ATLAS_LOCAL_PYTHON=true so skip ALRB python3"
+  else
+    log "Using ALRB to setup python3"
+    if [ -z "$ATLAS_LOCAL_ROOT_BASE" ]; then
+        export ATLAS_LOCAL_ROOT_BASE="${ATLAS_SW_BASE}/atlas.cern.ch/repo/ATLASLocalRootBase"
+    fi
+    export ALRB_LOCAL_PY3="YES"
+    source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh --quiet >/dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+      log "FATAL: failed to source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh"
+      err "FATAL: failed to source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh"
+      sortie 64
+    fi
+    if [ -z $ALRB_pythonVersion ]; then
+      lsetup -q "python pilot-default"
+    else
+      lsetup -q python
+    fi
+  fi
+}
+
+function check_python3() {
+  pybin=$(which python3)
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: python3 not found in PATH"
+    err "FATAL: python3 not found in PATH"
+    if [[ -z "${PATH}" ]]; then
+      log "In fact, PATH env var is unset mon amie"
+      err "In fact, PATH env var is unset mon amie"
+    fi
+    log "PATH content: ${PATH}"
+    err "PATH content: ${PATH}"
+    sortie 1
+  fi
+
+  pyver=$($pybin -c 'import sys; print("%i%02i" % (sys.version_info.major, sys.version_info.minor))')
+  # check if python version > 3.6
+  if [[ ${pyver} -ge 306 ]] ; then
+    log "Python version is > 3.6 (${pyver})"
+    log "Using ${pybin} for python compatibility"
+  else
+    log "ERROR: this site has python < 3.6"
+    err "ERROR: this site has python < 3.6"
+    log "Python ${pybin} is old: ${pyver}"
+
+    # Oh dear, we're doomed...
+    log "FATAL: Failed to find a compatible python, exiting"
+    err "FATAL: Failed to find a compatible python, exiting"
+    sortie 1
+  fi
+}
+
+function check_proxy() {
+  voms-proxy-info -all
+  if [[ $? -ne 0 ]]; then
+    log "WARNING: error running: voms-proxy-info -all"
+    err "WARNING: error running: voms-proxy-info -all"
+    arcproxy -I
+    if [[ $? -eq 127 ]]; then
+      log "FATAL: error running: arcproxy -I"
+      err "FATAL: error running: arcproxy -I"
+      sortie 1
+    fi
+  fi
+}
+
+function check_cvmfs() {
+  export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/sw}
+
+  CVMFS_BASE=${ATLAS_SW_BASE:-/cvmfs}
+  targets="${CVMFS_BASE}/atlas.cern.ch/repo/ATLASLocalRootBase/logDir/lastUpdate \
+           ${CVMFS_BASE}/atlas-condb.cern.ch/repo/conditions/logDir/lastUpdate \
+           ${CVMFS_BASE}/atlas-nightlies.cern.ch/repo/sw/logs/lastUpdate \
+           ${CVMFS_BASE}/sft.cern.ch/lcg/lastUpdate \
+           ${CVMFS_BASE}/unpacked.cern.ch/logDir/lastUpdate \
+           ${CVMFS_BASE}/sft-nightlies.cern.ch/lcg/lastUpdate"
+
+  for target in ${targets}; do
+    if [ $(cat ${target} | wc -l) -ge 1 ]; then
+      log "${target} is accessible"
+    else
+      log "WARNING: ${target} not accessible or empty, pilot to handle"
+      err "WARNING: ${target} not accessible or empty, pilot to handle"
+    fi
+  done
+}
+
+function setup_alrb() {
+  export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/ATLASLocalRootBase}
+  export ALRB_userMenuFmtSkip=YES
+  export ALRB_noGridMW=${ALRB_noGridMW:-NO}
+
+  log 'NOTE: rucio,davix,xrootd setup now done in local site setup atlasLocalSetup.sh'
+  if [[ ${iarg} == "RC" ]]; then
+    log 'RC pilot requested, setting ALRB_rucioVersion=testing'
+    log 'RC pilot, source $ATLAS_LOCAL_ROOT_BASE/etc/ADCPilotTesting.sh' 
+    source $ATLAS_LOCAL_ROOT_BASE/etc/ADCPilotTesting.sh
+    export ALRB_rucioVersion=testing
+  fi
+  if [[ ${iarg} == "ALRB" ]]; then
+    log 'ALRB pilot requested, setting ALRB env vars to testing'
+    export ALRB_adcTesting=YES
+  fi
+
+  if [[ ${ALRB_noGridMW} == "YES" ]]; then
+    log "Site has set ALRB_noGridMW=YES so use site native install rather than ALRB"
+    if [[ ${tflag} == 'true' ]]; then
+      log 'Skipping proxy checks due to -t flag'
+    else
+      check_vomsproxyinfo || check_arcproxy
+      if [[ $? -eq 1 ]]; then
+        log "FATAL: Site MW being used but proxy tools not found"
+        err "FATAL: Site MW being used but proxy tools not found"
+        sortie 1
+      fi
+    fi
+  else
+    log "Will use ALRB MW because ALRB_noGridMW=NO (default)"
+  fi
+
+}
+
+function setup_local() {
+  log "Looking for ${VO_ATLAS_SW_DIR}/local/setup.sh"
+  if [[ -f ${VO_ATLAS_SW_DIR}/local/setup.sh ]]; then
+    if [[ ${pythonversion} == '3' ]]; then
+      log "Sourcing ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg} -p python3"
+      source ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg} -p python3
+    else
+      log "Sourcing ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg}"
+      source ${VO_ATLAS_SW_DIR}/local/setup.sh -s ${qarg}
+    fi
+  else
+    log 'WARNING: No ATLAS local setup found'
+    err 'WARNING: this site has no local setup ${VO_ATLAS_SW_DIR}/local/setup.sh'
+  fi
+  # OSG MW setup, skip if not using ALRB Grid MW
+  if [[ ${ALRB_noGridMW} == "YES" ]]; then
+    if [[ -f ${OSG_GRID}/setup.sh ]]; then
+      log "Setting up OSG MW using ${OSG_GRID}/setup.sh"
+      source ${OSG_GRID}/setup.sh
+    else
+      log 'Env var ALRB_noGridMW=NO, not sourcing ${OSG_GRID}/setup.sh'
+    fi
+  fi
+
+}
+
+function setup_shoal() {
+  log "will set FRONTIER_SERVER with shoal"
+
+  outputstr=$(env -i FRONTIER_SERVER="$FRONTIER_SERVER"  /bin/bash -l -c "shoal-client -f")
+  if [[ $? -eq 0 ]] &&  [[ -n "${outputstr}" ]] ; then
+    export FRONTIER_SERVER=${outputstr}
+  else
+    log "WARNING: shoal-client had non-zero exit code or empty output"
+  fi
+
+  log "FRONTIER_SERVER = $FRONTIER_SERVER"
+}
+
+function setup_harvester_symlinks() {
+  for datafile in `find ${HARVESTER_WORKDIR} -maxdepth 1 -type l -exec /usr/bin/readlink -e {} ';'`; do
+      symlinkname=$(basename $datafile)
+      ln -s $datafile $symlinkname
+  done
+}
+
+
+function check_vomsproxyinfo() {
+  out=$(voms-proxy-info --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Check version: ${out}"
+    return 0
+  else
+    log "voms-proxy-info not found"
+    return 1
+  fi
+}
+
+function check_arcproxy() {
+  out=$(arcproxy --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Check version: ${out}"
+    return 0
+  else
+    log "arcproxy not found"
+    return 1
+  fi
+}
+
+function pilot_cmd() {
+
+  # test if not harvester job
+  if [[ ${harvesterflag} == 'false' ]] ; then
+    if [[ -n ${pilotversion} ]]; then
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} ${pilotargs}"
+    else
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} ${pilotargs}"
+    fi
+  else
+    # check to see if we are running OneToMany Harvester workflow (aka Jumbo Jobs)
+    if [[ ${workflowarg} == 'OneToMany' ]] && [ -z ${HARVESTER_PILOT_WORKDIR+x} ] ; then
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} -a ${HARVESTER_PILOT_WORKDIR} ${pilotargs}"
+    else
+      cmd="${pybin} ${pilotbase}/pilot.py -q ${qarg} -i ${iarg} -j ${jarg} ${pilotargs}"
+    fi
+  fi
+  echo ${cmd}
+}
+
+function sing_cmd() {
+  cmd="$BINARY_PATH exec $SINGULARITY_OPTIONS --env \"APFCID=$APFCID\" \
+                                              --env \"APFFID=$APFFID\" \
+                                              --env \"GRID_GLOBAL_JOBHOST=$GRID_GLOBAL_JOBHOST\" \
+                                              --env \"SCHEDD_NAME=$SCHEDD_NAME\" \
+                                              --env \"HARVESTER_ID=$HARVESTER_ID\" \
+                                              --env \"HARVESTER_WORKER_ID=$HARVESTER_WORKER_ID\" \
+                                              --env \"PANDA_AUTH_ORIGIN=$PANDA_AUTH_ORIGIN\" \
+                                              --env \"PANDA_AUTH_TOKEN=$PANDA_AUTH_TOKEN\" \
+                                              --env \"PANDA_AUTH_TOKEN_KEY=$PANDA_AUTH_TOKEN_KEY\" \
+                                              $IMAGE_PATH $0 $myargs"
+  echo ${cmd}
+}
+
+function sing_env() {
+  # preserve these env var in the apptainer environment
+  export APPTAINERENV_X509_USER_PROXY=${X509_USER_PROXY}
+  if [[ -n "${ATLAS_LOCAL_AREA}" ]]; then
+    export APPTAINERENV_ATLAS_LOCAL_AREA=${ATLAS_LOCAL_AREA}
+  fi
+  if [[ -n "${TMPDIR}" ]]; then
+    export APPTAINERENV_TMPDIR=${TMPDIR}
+  fi
+  if [[ -n "${RECOVERY_DIR}" ]]; then
+    export APPTAINERENV_RECOVERY_DIR=${RECOVERY_DIR}
+  fi
+  if [[ -n "${GTAG}" ]]; then
+    export APPTAINERENV_GTAG=${GTAG}
+  fi
+}
+
+function get_piloturl() {
+  local version=$1
+  local pilotdir=file://${ATLAS_SW_BASE}/atlas.cern.ch/repo/sw/PandaPilot/tar
+
+  if [[ -n ${piloturl} ]]; then
+    echo ${piloturl}
+    return 0
+  fi
+
+  if [[ ${version} == '1' ]]; then
+    log "FATAL: pilot version 1 requested, not supported by this wrapper"
+    err "FATAL: pilot version 1 requested, not supported by this wrapper"
+    sortie 1
+  elif [[ ${version} == '2' ]]; then
+    log "FATAL: pilot version 2 requested, not supported by this wrapper"
+    err "FATAL: pilot version 2 requested, not supported by this wrapper"
+    sortie 1
+  elif [[ ${version} == 'latest' ]]; then
+    pilottar=${pilotdir}/pilot3.tar.gz
+    pilotbase='pilot3'
+  elif [[ ${version} == 'current' ]]; then
+    pilottar=${pilotdir}/pilot3.tar.gz
+    pilotbase='pilot3'
+  elif [[ ${version} == '3' ]]; then
+    pilottar=${pilotdir}/pilot3.tar.gz
+    pilotbase='pilot3'
+  else
+    pilottar=${pilotdir}/pilot3-${version}.tar.gz
+    pilotbase='pilot3'
+  fi
+  echo ${pilottar}
+}
+
+function get_pilot() {
+
+  local url=$1
+
+  # remove pending chk from Lincoln
+  if [[ ${harvesterflag} == 'true' ]] && [[ ${workflowarg} == 'OneToMany' ]]; then
+    cp -v ${HARVESTER_WORK_DIR}/pilot2.tar.gz .
+  fi
+
+  if [[ ${url} == 'local' ]]; then
+    log "piloturl=local so download not needed"
+
+    if [[ -f pilot3.tar.gz ]]; then
+      log "local tarball pilot3.tar.gz exists OK"
+      tar -xzf pilot3.tar.gz
+      if [[ $? -ne 0 ]]; then
+        log "ERROR: pilot extraction failed for pilot3.tar.gz"
+        err "ERROR: pilot extraction failed for pilot3.tar.gz"
+        return 1
+      fi
+    elif [[ -f pilot2.tar.gz ]]; then
+      log "local tarball pilot2.tar.gz exists OK"
+      log "FATAL: pilot version 2 requested, not supported by this wrapper"
+      err "FATAL: pilot version 2 requested, not supported by this wrapper"
+      return 1
+    else
+      log "local pilot[23].tar.gz not found so assuming already extracted"
+    fi
+  else
+    curl --connect-timeout 30 --max-time 180 -sSL ${url} | tar -xzf -
+    if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+      log "ERROR: pilot download failed: ${url}"
+      err "ERROR: pilot download failed: ${url}"
+      return 1
+    fi
+  fi
+
+  if [[ -f ${pilotbase}/pilot.py ]]; then
+    log "File ${pilotbase}/pilot.py exists OK"
+    log "${pilotbase}/PILOTVERSION: $(cat ${pilotbase}/PILOTVERSION)"
+    return 0
+  else
+    log "ERROR: ${pilotbase}/pilot.py not found"
+    err "ERROR: ${pilotbase}/pilot.py not found"
+    return 1
+  fi
+}
+
+function muted() {
+  log "apfmon messages muted"
+}
+
+function apfmon_running() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+  log "APFCE: ${APFCE}"
+  echo -n "${VERSION} \
+         ${APFFID}:${APFCID} \
+         running 0 \
+         ${qarg:-unknown} \
+         ${APFCE:-unknown} \
+         ${HARVESTER_ID:-unknown} \
+         ${HARVESTER_WORKER_ID:-unknown} \
+         ${GTAG:-unknown}" \
+         > /dev/udp/148.88.96.15/28527
+}
+
+function apfmon_exiting() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+  log "APFCE: ${APFCE}"
+  duration=$(( $(date +%s) - ${starttime} ))
+  log "exiting ec=$1, duration=${duration}"
+  echo -n "${VERSION} \
+         ${APFFID}:${APFCID} \
+         exiting \
+         ${duration} \
+         ${qarg:-unknown} \
+         ${APFCE:-unknown} \
+         ${HARVESTER_ID:-unknown} \
+         ${HARVESTER_WORKER_ID:-unknown} \
+         ${GTAG:-unknown}" \
+         > /dev/udp/148.88.96.15/28527
+}
+
+function apfmon_fault() {
+  [[ ${mute} == 'true' ]] && muted && return 0
+  log "APFCE: ${APFCE}"
+  duration=$(( $(date +%s) - ${starttime} ))
+  log "${state} ec=$1, duration=${duration}"
+  echo -n "${VERSION} \
+         ${APFFID}:${APFCID} \
+         fault \
+         ${duration} \
+         ${qarg:-unknown} \
+         ${APFCE:-unknown} \
+         ${HARVESTER_ID:-unknown} \
+         ${HARVESTER_WORKER_ID:-unknown} \
+         ${GTAG:-unknown}" \
+         > /dev/udp/148.88.96.15/28527
+}
+
+function trap_handler() {
+  if [[ "$1" == '18' ]]; then
+    # SIGCONT caught so touch pilot log and pass signal to pilot process
+    log "WARNING: trap caught signal:$1, touching pilotlog.txt and signalling pilot PID: $pilotpid"
+    err "WARNING: trap caught signal:$1, touching pilotlog.txt and signalling pilot PID: $pilotpid"
+    touch pilotlog.txt
+    kill -s 18 $pilotpid
+  fi
+  if [[ -n "${pilotpid}" ]]; then
+    log "WARNING: trap caught signal:$1, signalling pilot PID: $pilotpid"
+    err "WARNING: trap caught signal:$1, signalling pilot PID: $pilotpid"
+    kill -s $1 $pilotpid
+    wait
+  else
+    log "WARNING: Caught $1 prior to pilot starting"
+  fi
+}
+
+function get_cricopts() {
+  container_opts=$(curl --silent $cricurl | grep container_options | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+      log "FATAL: failed to retrieve CRIC data from $cricurl"
+      err "FATAL: failed to retrieve CRIC data from $cricurl"
+      return 1
+    fi
+    cricopts=$(echo $container_opts | awk -F"\"" '{print $4}')
+    echo ${cricopts}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_catchall() {
+  local result
+  local content
+  result=$(curl --silent $cricurl | grep catchall | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    content=$(echo $result | awk -F"\"" '{print $4}')
+    echo ${content}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_environ() {
+  local result
+  local content
+  result=$(curl --silent $cricurl | grep environ | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    content=$(echo $result | awk -F"\"" '{print $4}')
+    echo ${content}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_resourcetype() {
+  local result
+  local content
+  result=$(curl --silent $cricurl | grep resource_type | grep -v null)
+  if [[ $? -eq 0 ]]; then
+    content=$(echo $result | awk -F"\"" '{print $4}')
+    echo ${content}
+    return 0
+  else
+    return 1
+  fi
+}
+
+function check_apptainer() {
+  BINARY_PATH="${ATLAS_SW_BASE}/atlas.cern.ch/repo/containers/sw/apptainer/`uname -m`-el9/current/bin/apptainer"
+  if [[ ${alma9flag} == 'true' ]]; then
+    IMAGE_PATH="${ATLAS_SW_BASE}/atlas.cern.ch/repo/containers/fs/singularity/`uname -m`-almalinux9"
+  else
+    IMAGE_PATH="${ATLAS_SW_BASE}/atlas.cern.ch/repo/containers/fs/singularity/`uname -m`-almalinux9"
+  fi
+  SINGULARITY_OPTIONS="$(get_cricopts) -B ${ATLAS_SW_BASE}:/cvmfs -B $PWD --cleanenv"
+  out=$(${BINARY_PATH} --version 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    log "Apptainer binary found, version $out"
+    log "Apptainer binary path: ${BINARY_PATH}"
+  else
+    log "Apptainer binary not found"
+  fi
+}
+
+function check_type() {
+  result=$(curl --silent $cricurl | grep container_type | grep 'singularity:wrapper')
+  if [[ $? -eq 0 ]]; then
+    log "CRIC container_type: singularity:wrapper found"
+    return 0
+  else
+    log "CRIC container_type: singularity:wrapper not found"
+    return 1
+  fi
+}
+
+function supervise_pilot() {
+  # check pilotlog.txt is being updated otherwise kill the pilot
+  local PILOT_PID=$1
+  local counter=0
+  while true; do
+    ((counter++))
+    err "supervise_pilot (15 min periods counter: ${counter})"
+    if [[ -f "pilotlog.txt" ]]; then
+      CURRENT_TIME=$(date +%s)
+      LAST_MODIFICATION=$(stat -c %Y "pilotlog.txt")
+      TIME_DIFF=$(( CURRENT_TIME - LAST_MODIFICATION ))
+
+      if [[ $TIME_DIFF -gt 3600 ]]; then
+        err "CURRENT_TIME: ${CURRENT_TIME}"
+        err "LAST_MODIFICATION: ${LAST_MODIFICATION}"
+        err "TIME_DIFF: ${TIME_DIFF}"
+        echo -n "TIME_DIFF ${TIME_DIFF} ${VERSION} ${qarg} ${APFFID}:${APFCID}" > /dev/udp/148.88.96.15/28527
+        echo -n "TIME_DIFF ${TIME_DIFF} ${VERSION} ${qarg} ${HARVESTER_ID}:${HARVESTER_WORKER_ID}" > /dev/udp/148.88.96.15/28527
+        log "pilotlog.txt has not been updated in the last hour. Sending SIGINT (2) signal to the pilot process."
+        err "pilotlog.txt has not been updated in the last hour. Sending SIGINT (2) signal to the pilot process."
+        echo -n "SIGINT 0 ${VERSION} ${qarg} ${APFFID}:${APFCID}" > /dev/udp/148.88.96.15/28527
+        echo -n "SIGINT 0 ${VERSION} ${qarg} ${HARVESTER_ID}:${HARVESTER_WORKER_ID}" > /dev/udp/148.88.96.15/28527
+        kill -s 2 $PILOT_PID > /dev/null 2>&1
+        touch wrapper_sigint_$PILOT_PID
+        sleep 180
+        if kill -s 0 $PILOT_PID > /dev/null 2>&1; then
+          log "The pilot process ($PILOT_PID) is still running after 3m. Sending SIGKILL (9)."
+          err "The pilot process ($PILOT_PID) is still running after 3m. Sending SIGKILL (9)."
+          kill -s 9 $PILOT_PID
+          touch wrapper_sigkill_$PILOT_PID
+        fi
+        exit 2
+      fi
+    else
+      log "pilotlog.txt does not exist (yet)"
+      err "pilotlog.txt does not exist (yet)"
+    fi
+
+    # Check every 15 mins
+    sleep 900
+  done
+}
+
+function panda_update_worker_pilot_status() {
+  log "Sending panda_update_worker_pilot_status started"
+  curl -sS -o /dev/null --insecure --compressed --connect-timeout 10 --max-time 20 \
+       --capath "${ATLAS_LOCAL_ROOT_BASE:-${ATLAS_SW_BASE:-/cvmfs}/atlas.cern.ch/repo/ATLASLocalRootBase}/etc/grid-security-emi/certificates" \
+       --cacert "${X509_USER_PROXY}" --cert "${X509_USER_PROXY}" --key "${X509_USER_PROXY}" \
+       -H "User-Agent: pilot-wrapper/${VERSION} ($(uname -sm))" \
+       -H 'Accept: application/json' \
+       --data-urlencode "workerID=${HARVESTER_WORKER_ID}" \
+       --data-urlencode "harvesterID=${HARVESTER_ID}" \
+       --data-urlencode 'status=started' \
+       --data-urlencode "site=${qarg}" \
+       --data-urlencode "node_id=$(hostname -f)" \
+       "${pandaurl}/server/panda/updateWorkerPilotStatus"
+}
+
+function hostinfo() {
+  echo
+  echo "---- Host details ----"
+  echo "hostname:" $(hostname -f)
+  echo "pwd:" $(pwd)
+  echo "whoami:" $(whoami)
+  echo "id:" $(id)
+  echo "getopt:" $(getopt -V 2>/dev/null)
+  echo "jq:" $(jq --version 2>/dev/null)
+  if [[ -r /proc/version ]]; then
+    echo "/proc/version:" $(cat /proc/version)
+  fi
+  echo "lsb_release:" $(lsb_release -d 2>/dev/null)
+  echo "SINGULARITY_ENVIRONMENT:" ${SINGULARITY_ENVIRONMENT}
+  echo BASHPID: ${BASHPID}
+  myargs=$@
+  echo "wrapper call: $0 $myargs"
+  cpuinfo_flags="flags: EMPTY"
+  if [ -f /proc/cpuinfo ]; then
+    cpuinfo_flags="$(grep '^flags' /proc/cpuinfo 2>/dev/null | sort -u 2>/dev/null)"
+    if [ -z "${cpuinfo_flags}" ]; then
+      cpuinfo_flags="flags: EMPTY"
+    fi
+  else
+    cpuinfo_flags="flags: EMPTY"
+  fi
+  echo "Flags from /proc/cpuinfo:"
+  echo ${cpuinfo_flags}
+  echo
+}
+
+function main() {
+  #
+  # Fail early, fail often^W with useful diagnostics
+  #
+  trap 'trap_handler 2' SIGINT
+  trap 'trap_handler 3' SIGQUIT
+  trap 'trap_handler 7' SIGBUS
+  trap 'trap_handler 10' SIGUSR1
+  trap 'trap_handler 11' SIGSEGV
+  trap 'trap_handler 12' SIGUSR2
+  trap 'trap_handler 15' SIGTERM
+  trap 'trap_handler 18' SIGCONT
+  trap 'trap_handler 24' SIGXCPU
+
+  if [[ -z ${SINGULARITY_ENVIRONMENT} ]]; then
+    # SINGULARITY_ENVIRONMENT not set
+    echo "This is ATLAS pilot wrapper version: $VERSION"
+    echo "Please send development requests to p.love@lancaster.ac.uk"
+    echo
+    log "==== wrapper stdout BEGIN ===="
+    err "==== wrapper stderr BEGIN ===="
+    UUID=$(cat /proc/sys/kernel/random/uuid)
+    #hostinfo
+    echo
+    echo "---- Host details ----"
+    echo "hostname:" $(hostname -f)
+    echo "pwd:" $(pwd)
+    echo "whoami:" $(whoami)
+    echo "id:" $(id)
+    echo "getopt:" $(getopt -V 2>/dev/null)
+    echo "jq:" $(jq --version 2>/dev/null)
+    if [[ -r /proc/version ]]; then
+      echo "/proc/version:" $(cat /proc/version)
+    fi
+    echo "lsb_release:" $(lsb_release -d 2>/dev/null)
+    echo "SINGULARITY_ENVIRONMENT:" ${SINGULARITY_ENVIRONMENT}
+    echo BASHPID: ${BASHPID}
+    myargs=$@
+    echo "wrapper call: $0 $myargs"
+    cpuinfo_flags="flags: EMPTY"
+    if [ -f /proc/cpuinfo ]; then
+      cpuinfo_flags="$(grep '^flags' /proc/cpuinfo 2>/dev/null | sort -u 2>/dev/null)"
+      if [ -z "${cpuinfo_flags}" ]; then
+        cpuinfo_flags="flags: EMPTY"
+      fi
+    else
+      cpuinfo_flags="flags: EMPTY"
+    fi
+    echo "Flags from /proc/cpuinfo:"
+    echo ${cpuinfo_flags}
+    echo
+    #
+    apfmon_running
+    panda_update_worker_pilot_status
+    log "${cricurl}"
+    echo
+    echo "---- Initial environment ----"
+    printenv
+    echo
+    echo "---- PWD content ----"
+    pwd
+    ls -la
+    echo
+
+    # CVMFS location needs to be defined fairly early in startup
+    if [[ ${cvmfsbaseflag} == 'true' ]]; then
+      echo "---- Configure CVMFS base path ----"
+      # Log that the CVMFS base is not the usual place
+      log "CVMFS base path defined from commandline: ${cvmfsbasearg}"
+      echo
+    fi
+    export ATLAS_SW_BASE=${cvmfsbasearg}
+
+    echo "---- Check singularity details  ----"
+    cric_opts=$(get_cricopts)
+    if [[ $? -eq 0 ]]; then
+      log "CRIC container_options: $cric_opts"
+    else
+      log "FATAL: failed to get CRIC container_options"
+      err "FATAL: failed to get CRIC container_options"
+      sortie 1
+    fi
+
+    check_type
+    if [[ $? -eq 0 ]]; then
+      use_singularity=true
+      log "container_type contains singularity:wrapper, so use_singularity=true"
+    else
+      use_singularity=false
+    fi
+
+    if [[ ${use_singularity} = true ]]; then
+      # check if already in SINGULARITY environment
+      log 'SINGULARITY_ENVIRONMENT is not set'
+      sing_env
+      log 'Setting SINGULARITY_env'
+      check_apptainer
+      export ALRB_noGridMW=NO
+      cmd=$(sing_cmd)
+      echo "cmd: $cmd"
+      echo
+      log '==== singularity stdout BEGIN ===='
+      err '==== singularity stderr BEGIN ===='
+      $cmd &
+      singpid=$!
+      wait $singpid
+      singrc=$?
+      log "singularity return code: $singrc"
+      log '==== singularity stdout END ===='
+      err '==== singularity stderr END ===='
+      log "==== wrapper stdout END ===="
+      err "==== wrapper stderr END ===="
+      exit $singrc
+    else
+      log 'Will NOT use singularity, at least not from the wrapper'
+    fi
+    echo
+  else
+    log 'SINGULARITY_ENVIRONMENT is set, run basic setup'
+    export ALRB_noGridMW=NO
+    # Ensure that the ATLAS_SW_BASE gets defined to /cvmfs inside of
+    # singularity/apptainer.
+    export ATLAS_SW_BASE=/cvmfs
+    df -h
+  fi
+  echo
+
+  echo "---- Enter workdir ----"
+  workdir=$(get_workdir)
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: error with get_workdir"
+    err "FATAL: error with get_workdir"
+    sortie 1
+  fi
+  log "Workdir: ${workdir}"
+  if [[ -f pandaJobData.out ]]; then
+    log "Copying job description to working dir"
+    cp pandaJobData.out $workdir/pandaJobData.out
+  fi
+  if [[ -f ${PANDA_AUTH_TOKEN} ]]; then
+    log "Copying PanDA auth token to working dir"
+    cp ${PANDA_AUTH_TOKEN} $workdir/${PANDA_AUTH_TOKEN}
+  fi
+  log "cd ${workdir}"
+  cd ${workdir}
+  if [[ ${harvesterflag} == 'true' ]]; then
+        export HARVESTER_PILOT_WORKDIR=${workdir}
+        log "Define HARVESTER_PILOT_WORKDIR : ${HARVESTER_PILOT_WORKDIR}"
+  fi
+  echo
+
+  echo "---- Retrieve pilot code ----"
+  piloturl=$(get_piloturl ${pilotversion})
+  log "Using piloturl: ${piloturl}"
+
+  log "Only supporting pilot3 so pilotbase directory: pilot3"
+  pilotbase='pilot3'
+  echo
+
+  get_pilot ${piloturl}
+  if [[ $? -ne 0 ]]; then
+    log "FATAL: failed to get pilot code, from node: $(hostname -f)"
+    err "FATAL: failed to get pilot code, from node: $(hostname -f)"
+    sortie 64
+  fi
+  echo
+
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping defining VO_ATLAS_SW_DIR due to --container flag'
+    log 'Skipping defining ATLAS_LOCAL_ROOT_BASE due to --container flag'
+  else
+    export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/sw}
+    export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/ATLASLocalRootBase}
+  fi
+  echo
+
+  echo "---- Shell process limits ----"
+  ulimit -a
+  echo
+
+  echo "---- Check cvmfs area ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Check cvmfs area due to --container flag'
+  else
+    check_cvmfs
+  fi
+  echo
+
+  echo "--- Bespoke environment from CRIC ---"
+  result=$(get_environ)
+  if [[ $? -eq 0 ]]; then
+    if [[ -z ${result} ]]; then
+      log 'CRIC environ field: <empty>'
+    else
+      log 'CRIC environ content'
+      log "export ${result}"
+      export ${result}
+    fi
+  else
+    log 'No content found in CRIC environ'
+  fi
+  resource_type=$(get_resourcetype)
+  echo
+
+  echo "---- Setup ALRB ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Setup ALRB due to --container flag'
+  else
+    :
+    setup_alrb
+  fi
+  echo
+
+  echo "---- Check python version ----"
+  if [[ ${pythonversion} == '3' ]]; then
+    log "python3 selected from cmdline"
+    setup_python3
+    check_python3
+  else
+    log "Default python2 selected from cmdline"
+    check_python2
+  fi
+  echo
+
+  echo "---- Setup local ATLAS ----"
+  if [[ ${containerflag} == 'true' ]]; then
+    log 'Skipping Setup local ATLAS due to --container flag'
+  else
+    setup_local
+  fi
+  echo
+
+  echo "---- Setup logstash ----"
+  log 'Running lsetup logstash'
+  lsetup -q logstash
+  echo
+
+  echo "---- Setup psutil ----"
+  log 'Running lsetup psutil'
+  lsetup -q psutil
+  echo
+
+  echo "---- Setup stomp ----"
+  result=$(get_catchall)
+  if [[ $? -eq 0 ]]; then
+    if grep -q "messaging=stomp" <<< "$result"; then
+      log 'Stomp requested via CRIC catchall, running lsetup stomp'
+      lsetup -q stomp
+    else
+      log 'Stomp not requested in CRIC catchall'
+    fi
+  else
+    log 'No content found in CRIC catchall'
+  fi
+  echo
+
+
+  if [[ ${harvesterflag} == 'true' ]]; then
+    echo "---- Create symlinks to input data ----"
+    log 'Create to symlinks to input data from harvester info'
+    setup_harvester_symlinks
+    echo
+  fi
+
+  if [[ "${shoalflag}" == 'true' ]]; then
+    echo "--- Setup shoal ---"
+    setup_shoal
+    echo
+  fi
+
+  echo "---- Proxy Information ----"
+  if [[ ${tflag} == 'true' ]]; then
+    log 'Skipping proxy checks due to -t flag'
+  else
+    check_proxy
+  fi
+
+  echo "---- Job Environment ----"
+  printenv
+  echo
+  if [[ -n ${ATLAS_LOCAL_AREA} ]]; then
+    log "Content of $ATLAS_LOCAL_AREA/setup.sh.local"
+    cat $ATLAS_LOCAL_AREA/setup.sh.local
+    echo
+  else
+    log "Empty: \$ATLAS_LOCAL_AREA"
+    echo
+  fi
+
+  echo "---- Build pilot cmd ----"
+  cmd=$(pilot_cmd)
+  echo $cmd
+  echo
+
+  echo "---- Ready to run pilot ----"
+  echo
+
+  log "==== pilot stdout BEGIN ===="
+  $cmd &
+  pilotpid=$!
+  supervise_pilot ${pilotpid} &
+  SUPERVISOR_PID=$!
+  err "Started supervisor process ($SUPERVISOR_PID) (watching ${pilotpid})" 
+  wait $pilotpid >/dev/null 2>&1
+  pilotrc=$?
+  log "==== pilot stdout END ===="
+  log "==== wrapper stdout RESUME ===="
+  log "pilotpid: $pilotpid"
+  log "Pilot exit status: $pilotrc"
+
+  if [[ -f ${workdir}/${pilotbase}/pandaIDs.out ]]; then
+    # max 30 pandaids
+    pandaids=$(cat ${workdir}/${pilotbase}/pandaIDs.out | xargs echo | cut -d' ' -f-30)
+    log "pandaids: ${pandaids}"
+  else
+    log "File not found: ${workdir}/${pilotbase}/pandaIDs.out, no payload"
+    err "File not found: ${workdir}/${pilotbase}/pandaIDs.out, no payload"
+    pandaids=''
+  fi
+
+  # pilot handling of signals:
+  # errors.KILLSIGNAL: [137, "General kill signal"],  # Job terminated by unknown kill signal
+  # errors.SIGTERM: [143, "Job killed by signal: SIGTERM"],  # 128+15
+  # errors.SIGQUIT: [131, "Job killed by signal: SIGQUIT"],  # 128+3
+  # errors.SIGSEGV: [139, "Job killed by signal: SIGSEGV"],  # 128+11
+  # errors.SIGXCPU: [152, "Job killed by signal: SIGXCPU"],  # 128+24
+  # errors.SIGUSR1: [138, "Job killed by signal: SIGUSR1"],  # 128+10
+  # errors.SIGINT: [130, "Job killed by signal: SIGINT"],  # 128+2
+  # errors.SIGBUS: [135, "Job killed by signal: SIGBUS"]   # 128+7
+
+
+  if [[ $pilotrc -eq 130 ]]; then
+    # killed by supervisor SIGINT so use exitcode 2
+    sortie 2
+  elif [[ $pilotrc -eq 143 ]]; then
+    # killed by SIGTERM, presumably LRMS
+    sortie 1
+  elif [[ $pilotrc -eq 137 ]]; then
+    if [[ -f "wrapper_sigkill_$pilotpid" ]]; then
+      err "Found: wrapper_sigkill_$pilotpid, so killed by wrapper"
+      # killed by wrapper SIGKILL
+      sortie 2
+    else
+      # killed by some other SIGKILL, presumably LRMS
+      err "Not found: wrapper_sigkill_$pilotpid, so not killed by wrapper"
+      sortie 1
+    fi
+  elif [[ $pilotrc -eq 64 ]]; then
+    sortie 64
+  elif [[ $pilotrc -eq 80 ]]; then
+    log "WARNING: pilot exitcode=80, proxy lifetime too short"
+    err "WARNING: pilot exitcode=80, proxy lifetime too short"
+    sortie 80
+  elif [[ $pilotrc -eq 82 ]]; then
+    log "WARNING: pilot exitcode=82, no payload"
+    err "WARNING: pilot exitcode=82, no payload"
+    if [[ ${resource_type} == "hpc_special" ]]; then
+      sortie 82
+    else
+      sortie 0
+    fi
+  elif [[ $pilotrc -ne 0 ]]; then
+    log "WARNING: pilot exitcode non-zero: ${pilotrc}"
+    err "WARNING: pilot exitcode non-zero: ${pilotrc}"
+    sortie $pilotrc
+  fi
+
+  sortie 0
+}
+
+function usage () {
+  echo "Usage: $0 -q <queue> -r <resource> -s <site> [<pilot_args>]"
+  echo
+  echo "  --container (Standalone container), file to source for release setup "
+  echo "  --cvmfsbase (CVMFSExec), path to CVMFS base, default '/cvmfs'"
+  echo "  --alma9 use alma9 container image"
+  echo "  --harvester (Harvester at HPC edge), NodeID from HPC batch system "
+  echo "  -i,   pilot type, default PR"
+  echo "  -j,   job type prodsourcelabel, default 'managed'"
+  echo "  -q,   panda queue"
+  echo "  -r,   panda resource"
+  echo "  -s,   sitename for local setup"
+  echo "  -t,   pass -t option to pilot, skipping proxy check"
+  echo "  -S,   setup shoal client"
+  echo "  --piloturl, URL of pilot code tarball"
+  echo "  --pilotversion, request particular pilot version"
+  echo "  --pythonversion,   valid values '2' (default), and '3'"
+  echo "  --localpy, skip ALRB setup and use local python"
+  echo
+  exit 1
+}
+
+starttime=$(date +%s)
+
+containerflag='false'
+containerarg=''
+cvmfsbaseflag='false'
+if [ -z ${ATLAS_SW_BASE} ]; then 
+  cvmfsbasearg='/cvmfs'
+else   
+  cvmfsbasearg="$ATLAS_SW_BASE"
+fi
+alma9flag='false'
+harvesterflag='false'
+harvesterarg=''
+workflowarg=''
+iarg='PR'
+jarg='managed'
+qarg=''
+rarg=''
+shoalflag='false'
+localpyflag='false'
+tflag='false'
+#pandaurl='http://pandaserver.cern.ch:25085'
+pandaurl='https://pandaserver.cern.ch:25443'
+piloturl=''
+pilotversion='latest'
+pilotbase='pilot3'
+pythonversion='3'
+mute='false'
+myargs="$@"
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    -h|--help)
+    usage
+    shift
+    shift
+    ;;
+    --container)
+    containerflag='true'
+    #containerarg="$2"
+    #shift
+    shift
+    ;;
+    --cvmfsbase)
+    cvmfsbaseflag='true'
+    cvmfsbasearg="$2"
+    shift
+    shift
+    ;;
+    --alma9)
+    alma9flag='true'
+    shift
+    ;;
+    --harvester)
+    harvesterflag='true'
+    harvesterarg="$2"
+    mute='true'
+    pandaurl='https://pandaserver.cern.ch:25443'
+    piloturl='local'
+    shift
+    shift
+    ;;
+    --harvester_workflow)
+    harvesterflag='true'
+    workflowarg="$2"
+    shift
+    shift
+    ;;
+    --mute)
+    mute='true'
+    shift
+    ;;
+    --pilotversion)
+    pilotversion="$2"
+    shift
+    shift
+    ;;
+    --pythonversion)
+    pythonversion="$2"
+    shift
+    shift
+    ;;
+    --piloturl)
+    piloturl="$2"
+    shift
+    shift
+    ;;
+    -i)
+    iarg="$2"
+    shift
+    shift
+    ;;
+    -j)
+    jarg="$2"
+    shift
+    shift
+    ;;
+    -q)
+    qarg="$2"
+    shift
+    shift
+    ;;
+    -r)
+    rarg="$2"
+    shift
+    shift
+    ;;
+    -s)
+    sarg="$2"
+    shift
+    shift
+    ;;
+    --localpy)
+    localpyflag=true
+    shift
+    ;;
+    -S|--shoal)
+    shoalflag=true
+    shift
+    ;;
+    -t)
+    tflag='true'
+    POSITIONAL+=("$1") # save it in an array for later
+    shift
+    ;;
+    *)
+    POSITIONAL+=("$1") # save it in an array for later
+    shift
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [ -z "${qarg}" ]; then usage; exit 1; fi
+
+pilotargs="$@"
+
+if [[ -f queuedata.json ]]; then
+  cricurl="file://${PWD}/queuedata.json"
+else
+  cricurl="http://pandaserver.cern.ch:25085/cache/schedconfig/${qarg}.all.json"
+fi
+
+fabricmon="http://apfmon.lancs.ac.uk/api"
+if [ -z ${APFMON} ]; then
+  APFMON=${fabricmon}
+fi
+if [[ -n "${GRID_GLOBAL_JOBHOST}" ]]; then
+  # ARCCE
+  declare -g APFCE="${GRID_GLOBAL_JOBHOST}"
+elif [[ -n "${SCHEDD_NAME}" ]]; then
+  # HTCONDORCE
+  declare -g APFCE="${SCHEDD_NAME}"
+elif [[ -n "${CONDORCE_COLLECTOR_HOST}" ]]; then
+  # HTCONDORCE
+  declare -g APFCE="${CONDORCE_COLLECTOR_HOST%:*}"
+else
+  declare -g APFCE="unknown"
+fi
+main "$myargs"


### PR DESCRIPTION
## Summary

- Add ATLAS queue config (`atlas.panda_queueconfig.json`) and DOMA queue config (`doma.panda_queueconfig.json`)
- Add ATLAS sandbox scripts: `atlas.init-harvester`, `atlas.run-harvester-crons`, `atlas.runpilot2-wrapper.sh`, `atlas.submit_pilot.sdf`
- Add DOMA sandbox scripts: `doma.run-harvester-crons`, `doma.vomsproxy-renew`, `doma.vomsproxy-renew-eic`, `runpilot2-wrapper-doma.sh`, `runpilot2-wrapper.sh`
- Add site-specific submit descriptors: `bnl_osg.submit_pilot_token_push.sdf`, `cnaf_darkside.submit_pilot_token_push.sdf`

## Test plan

- [ ] Verify ATLAS harvester deploys with `atlas.panda_queueconfig.json`
- [ ] Verify DOMA harvester deploys with `doma.panda_queueconfig.json`
- [ ] Verify init and cron scripts execute correctly in the harvester container
- [ ] Verify pilot submission works for BNL/OSG and CNAF/Darkside sites