### PR TITLE
Fix ArgoCD testbed value file paths for idds and bigmon

### DIFF
--- a/argocd-apps/testbed/bigmon.yaml
+++ b/argocd-apps/testbed/bigmon.yaml
@@ -12,7 +12,7 @@ spec:
     helm:
       valueFiles:
         - values.yaml
-        - values-atlas_testbed.yaml
+        - values/values-atlas_testbed.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/argocd-apps/testbed/idds.yaml
+++ b/argocd-apps/testbed/idds.yaml
@@ -12,7 +12,7 @@ spec:
     helm:
       valueFiles:
         - values.yaml
-        - values-atlas_testbed.yaml
+        - values/values-atlas_testbed.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: default


### PR DESCRIPTION
## Summary

- The `valueFiles` entries for `idds` and `bigmon` in `argocd-apps/testbed/` referenced `values-atlas_testbed.yaml` directly, but the file lives under the `values/` subdirectory
- Corrected the paths to `values/values-atlas_testbed.yaml` to match the actual chart layout (consistent with how `panda.yaml` already references it)

## Test plan

- [ ] Verify ArgoCD successfully syncs the `panda-idds` application with the corrected path
- [ ] Verify ArgoCD successfully syncs the `panda-bigmon` application with the corrected path