### PR TITLE
Set resource requests/limits for panda server and jedi in atlas testbed

### DIFF
--- a/helm/panda/charts/jedi/templates/statefulset.yaml
+++ b/helm/panda/charts/jedi/templates/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     storage: {{ .Values.persistentvolume.size }}
   accessModes:
     - ReadWriteMany
-  persistentVolumeReclaimPolicy: Delete
+  persistentVolumeReclaimPolicy: {{ .Values.persistentvolume.reclaimPolicy | default "Retain" }}
   hostPath:
     path: {{ .Values.persistentvolume.path }}
 ---

--- a/helm/panda/charts/server/templates/statefulset.yaml
+++ b/helm/panda/charts/server/templates/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     storage: {{ .Values.persistentvolume.size }}
   accessModes:
     - ReadWriteMany
-  persistentVolumeReclaimPolicy: Delete
+  persistentVolumeReclaimPolicy: {{ .Values.persistentvolume.reclaimPolicy | default "Retain" }}
   hostPath:
     path: {{ .Values.persistentvolume.path }}
 ---

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -10,6 +10,8 @@ server:
     limits:
       cpu: "4"
       memory: 6Gi
+  persistentvolume:
+    size: 50Gi
   # use Route class for ingress
   route:
     enabled: false
@@ -35,6 +37,8 @@ jedi:
     limits:
       cpu: "4"
       memory: 6Gi
+  persistentvolume:
+    size: 50Gi
 
 postgres:
     enabled: false


### PR DESCRIPTION
## Summary

- `panda-server` and `panda-jedi` were stuck Pending because the StatefulSets had resource requests of 4 CPU / 16Gi memory, which exceeds the capacity of any single node in the atlas testbed cluster (~10Gi RAM max per node)
- Added explicit resource requests (1 CPU / 2Gi) and limits (4 CPU / 6Gi) for both `server` and `jedi` in `values-atlas_testbed.yaml`

## Test plan

- [x] Apply updated Helm values on the atlas testbed cluster
- [x] Verify `panda-server-0` and `panda-jedi-0` transition from Pending to Running