### PR TITLE
Add atlas testbed resource overrides for harvester

### DIFF
--- a/argocd-apps/testbed/harvester.yaml
+++ b/argocd-apps/testbed/harvester.yaml
@@ -12,6 +12,7 @@ spec:
     helm:
       valueFiles:
         - values.yaml
+        - values/values-atlas_testbed.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -1,0 +1,20 @@
+# Default values for harvester - atlas testbed overrides.
+# This is a YAML-formatted file.
+
+harvester:
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "4"
+      memory: 6Gi
+
+mariadb:
+  resources:
+    requests:
+      cpu: "500m"
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi


### PR DESCRIPTION
## Summary

- harvester and mariadb defaulted to 4 CPU / 16Gi (hardcoded in `values.yaml`) which exceeds the testbed node capacity
- Created `values/values-atlas_testbed.yaml` for harvester with appropriate resource requests/limits
- Updated the ArgoCD `harvester.yaml` manifest to load the new values file (consistent with how panda, idds, and bigmon apps reference their testbed values)

## Test plan

- [ ] Verify `panda-harvester` ArgoCD app syncs and pods schedule successfully on the testbed cluster