### PR TITLE
Fix ArgoCD sync issues for bigmon and harvester in atlas testbed

### DIFF
--- a/argocd-apps/testbed/bigmon.yaml
+++ b/argocd-apps/testbed/bigmon.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd-apps/testbed/harvester.yaml
+++ b/argocd-apps/testbed/harvester.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true

--- a/helm/bigmon/values/values-atlas_testbed.yaml
+++ b/helm/bigmon/values/values-atlas_testbed.yaml
@@ -6,6 +6,7 @@
 main:
   persistentvolume:
     create: true
+    size: 50Gi
 
   ingress:
     enabled: true

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -2,6 +2,12 @@
 # This is a YAML-formatted file.
 
 harvester:
+  persistentvolume:
+    size: 50Gi
+  persistentvolumewdir:
+    size: 50Gi
+  persistentvolumecondor:
+    size: 50Gi
   resources:
     requests:
       cpu: "1"


### PR DESCRIPTION
## Summary

- Add `ServerSideApply=true` to `bigmon` and `harvester` ArgoCD app manifests — both have large ConfigMaps (`panda-bigmon-main-sandbox`, `panda-harvester-sandbox`) that exceed the 256KB client-side apply annotation limit
- Set bigmon PV size to 50Gi in `values-atlas_testbed.yaml` to match the existing PVC (chart default is 5Gi)
- Set harvester main/wdir/condor PV sizes to 50Gi for adequate log and working directory space

## Test plan

- [ ] Verify `panda-bigmon` ArgoCD app syncs successfully
- [ ] Verify `panda-harvester` ArgoCD app syncs successfully
- [ ] Verify harvester and bigmon pods schedule and reach Running state