### PR TITLE
fix(harvester): add missing mariadb custom configmap template

### DIFF
--- a/helm/harvester/charts/mariadb/templates/configmap.yaml
+++ b/helm/harvester/charts/mariadb/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mariadb.fullname" . }}-custom
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+data:
+  my_custom.cnf: |-
+    {{- .Values.customConfig | nindent 4 }}

--- a/helm/harvester/charts/mariadb/values.yaml
+++ b/helm/harvester/charts/mariadb/values.yaml
@@ -70,3 +70,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Custom MariaDB configuration appended to /opt/bitnami/mariadb/conf/my_custom.cnf
+customConfig: |-
+  [mysqld]
+  max_allowed_packet=128M
+  innodb_buffer_pool_size=512M


### PR DESCRIPTION
## Summary
- The mariadb statefulset mounts a `-custom` ConfigMap at `/opt/bitnami/mariadb/conf/my_custom.cnf` but no template existed for it
- This caused `panda-harvester-mariadb` to fail to start on a fresh cluster unless the ConfigMap was created manually
- Add the ConfigMap template with a `customConfig` value (defaults to `max_allowed_packet=128M` and `innodb_buffer_pool_size=512M`)

## Test plan
- [ ] Verify mariadb starts on a fresh cluster without manual ConfigMap creation
- [ ] Verify custom config can be overridden via values