### PR TITLE
fix(bigmon): set TNS_ADMIN for Oracle thick client name resolution

### DIFF
--- a/secrets/templates/bigmon.yaml
+++ b/secrets/templates/bigmon.yaml
@@ -41,6 +41,9 @@ stringData:
 
   # PandaDB
   PANDA_DB_BACKEND: "{{ $dbBackend }}"
+  {{- if eq $dbBackend "oracle" }}
+  TNS_ADMIN: "/data/bigmon/config"
+  {{- end }}
   {{- if .Values.bigmon.dbhost }}
   PANDA_DB_NAME: "{{ .Values.bigmon.dbname  }}"
   PANDA_DB_HOST: "{{ .Values.bigmon.dbhost }}"


### PR DESCRIPTION
## Summary
- When using Oracle backend, oracledb thick mode needs TNS_ADMIN set to the directory containing tnsnames.ora
- The file is already present at /data/bigmon/config/ (copied from the sandbox configmap by the init script) but without TNS_ADMIN the client cannot resolve TNS names like INT8R, causing ORA-12545
- Set TNS_ADMIN=/data/bigmon/config in the bigmon envs secret when database.backend is oracle

## Test plan
- [ ] Verify TNS_ADMIN is set in the pod env and Oracle connects successfully (no more ORA-12545)
- [ ] Verify no impact on PostgreSQL-backed deployments