### PR TITLE
fix(secrets): use bigmon.database.* keys in bigmon template, fix Oracle TNS config

### DIFF
--- a/secrets/templates/bigmon.yaml
+++ b/secrets/templates/bigmon.yaml
@@ -44,12 +44,12 @@ stringData:
   {{- if eq $dbBackend "oracle" }}
   TNS_ADMIN: "/data/bigmon/config"
   {{- end }}
-  {{- if .Values.bigmon.dbhost }}
-  PANDA_DB_NAME: "{{ .Values.bigmon.dbname  }}"
-  PANDA_DB_HOST: "{{ .Values.bigmon.dbhost }}"
-  PANDA_DB_PORT: "{{ .Values.bigmon.dbport }}"
-  PANDA_DB_USER: "{{ .Values.bigmon.dbuser }}"
-  PANDA_DB_PASSWORD: {{ .Values.bigmon.dbpassword }}
+  {{- if .Values.bigmon.database }}
+  PANDA_DB_NAME: "{{ .Values.bigmon.database.name }}"
+  PANDA_DB_HOST: "{{ .Values.bigmon.database.dbhost }}"
+  PANDA_DB_PORT: "{{ .Values.bigmon.database.dbport }}"
+  PANDA_DB_USER: "{{ .Values.bigmon.database.user }}"
+  PANDA_DB_PASSWORD: {{ .Values.bigmon.database.password }}
   {{- else }}
   PANDA_DB_NAME: "{{ .Values.panda.database.name }}"
   PANDA_DB_HOST: "{{ .Values.panda.database.dbhost | default (printf "%s-postgres" (include "panda_ref" .)) }}"


### PR DESCRIPTION
## Summary
- The bigmon secrets template was using flat keys (`bigmon.dbhost`, `bigmon.dbname`, etc.) but the values structure uses nested `bigmon.database.*` keys
- This caused the bigmon-specific DB block to never render (condition `if .Values.bigmon.dbhost` was always false), silently falling back to panda DB credentials instead of bigmon credentials
- Fix: update the condition to `if .Values.bigmon.database` and use `bigmon.database.*` field references throughout

## Note on Oracle TNS connections
For Oracle with a TNS alias (e.g. `INT8R`), set in values:
- `bigmon.database.name: "INT8R"` — TNS alias goes in NAME
- `bigmon.database.dbhost: ""` — HOST must be empty to trigger TNS resolution (non-empty HOST causes direct TCP connection attempt, bypassing TNS)

## Test plan
- [ ] Verify bigmon pod env shows correct `PANDA_DB_USER` (bigmon-specific, not panda user)
- [ ] Verify Oracle connection succeeds with TNS alias in NAME and empty HOST