### PR TITLE
fix(secrets): add SOCIAL_AUTH_CERNOIDC_* aliases from cern provider key

### DIFF
--- a/secrets/templates/bigmon.yaml
+++ b/secrets/templates/bigmon.yaml
@@ -38,6 +38,11 @@ stringData:
   SOCIAL_AUTH_{{ upper $provider }}_{{ upper $kk }}: {{ $vv }}
   {{- end }}
   {{- end }}
+  # CERNOIDC aliases — local.py.template uses SOCIAL_AUTH_CERNOIDC_* variable names
+  {{- if .Values.bigmon.auth.providers.cern }}
+  SOCIAL_AUTH_CERNOIDC_KEY: {{ .Values.bigmon.auth.providers.cern.key }}
+  SOCIAL_AUTH_CERNOIDC_SECRET: {{ .Values.bigmon.auth.providers.cern.secret }}
+  {{- end }}
 
   # PandaDB
   PANDA_DB_BACKEND: "{{ $dbBackend }}"


### PR DESCRIPTION
## Summary
- `local.py.template` uses `SOCIAL_AUTH_CERNOIDC_KEY/SECRET` variable names
- The provider loop generates `SOCIAL_AUTH_CERN_KEY/SECRET` from the `cern:` provider key, which is needed for the login button display in `BIGMON_AUTH_PROVIDER_LIST`
- Add explicit `SOCIAL_AUTH_CERNOIDC_KEY/SECRET` aliases mapped from `bigmon.auth.providers.cern.key/secret` so both the provider list and the CERNOIDC backend config are set correctly

## Test plan
- [ ] Verify CERN SSO and Google login buttons appear on bigmon
- [ ] Verify `SOCIAL_AUTH_CERNOIDC_KEY` is set correctly in pod env