### PR TITLE
fix: quote SOCIAL_AUTH_CERNOIDC values and replace em dash in comment

### DIFF
--- a/secrets/templates/bigmon.yaml
+++ b/secrets/templates/bigmon.yaml
@@ -38,10 +38,10 @@ stringData:
   SOCIAL_AUTH_{{ upper $provider }}_{{ upper $kk }}: {{ $vv }}
   {{- end }}
   {{- end }}
-  # CERNOIDC aliases — local.py.template uses SOCIAL_AUTH_CERNOIDC_* variable names
+  # CERNOIDC aliases - local.py.template uses SOCIAL_AUTH_CERNOIDC_* variable names
   {{- if .Values.bigmon.auth.providers.cern }}
-  SOCIAL_AUTH_CERNOIDC_KEY: {{ .Values.bigmon.auth.providers.cern.key }}
-  SOCIAL_AUTH_CERNOIDC_SECRET: {{ .Values.bigmon.auth.providers.cern.secret }}
+  SOCIAL_AUTH_CERNOIDC_KEY: "{{ .Values.bigmon.auth.providers.cern.key }}"
+  SOCIAL_AUTH_CERNOIDC_SECRET: "{{ .Values.bigmon.auth.providers.cern.secret }}"
   {{- end }}
 
   # PandaDB


### PR DESCRIPTION
Fix YAML parse error caused by em dash character in comment and unquoted secret values.