### PR TITLE
fix(idds): configure Oracle backend, disable postgres subchart

### DIFF
--- a/helm/idds/charts/rest/idds_configmap.json
+++ b/helm/idds/charts/rest/idds_configmap.json
@@ -3,7 +3,7 @@
         {"common":
             {"loglevel": "DEBUG"},
          "database":
-            {"default": "postgresql://${IDDS_DATABASE_USER}:${IDDS_DATABASE_PASSWORD}@${IDDS_DATABASE_HOST}:${IDDS_DATABASE_PORT}/${IDDS_DATABASE_NAME}?keepalives=1&keepalives_idle=30&keepalives_interval=5&keepalives_count=5",
+            {"default": "${IDDS_DATABASE_URL}",
              "schema": "${IDDS_DATABASE_SCHEMA}",
              "pool_size": 50,
              "pool_recycle": 3600,
@@ -95,7 +95,7 @@
         },
     "/opt/idds/config/idds/alembic.ini":
         {"alembic":
-            {"sqlalchemy.url": "postgresql://${IDDS_DATABASE_USER}:${IDDS_DATABASE_PASSWORD}@${IDDS_DATABASE_HOST}:${IDDS_DATABASE_PORT}/${IDDS_DATABASE_NAME}",
+            {"sqlalchemy.url": "${IDDS_DATABASE_URL}",
              "version_table_schema": "${IDDS_DATABASE_SCHEMA}"
             }
         },

--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -117,7 +117,7 @@ spec:
           {{ if .Values.autoStart -}}
           command: ["/bin/sh", "-c"]
           args:
-            - until /usr/bin/pg_isready -h ${IDDS_DATABASE_HOST} -p ${IDDS_DATABASE_PORT}; do echo waiting for database; sleep 2; done;
+            - if [ "${IDDS_DB_BACKEND}" != "oracle" ]; then until /usr/bin/pg_isready -h ${IDDS_DATABASE_HOST} -p ${IDDS_DATABASE_PORT}; do echo waiting for database; sleep 2; done; fi;
               {{- if .Values.noRoot }}
               /opt/idds/bin/start-daemon.sh all
               {{- else }}
@@ -137,6 +137,8 @@ spec:
                 name: {{ include "rest.fullname" . }}-envs
             - secretRef:
                 name: {{ .Values.global.secret }}-idds-envs
+            - secretRef:
+                name: {{ .Values.global.secret }}-idds-db-envs
           env:
             - name: IDDS_REST_HOST
               value: "{{ .Values.restHost }}"
@@ -173,6 +175,8 @@ spec:
                   name: {{ include "rest.fullname" . }}-configmap
               - secret:
                   name: {{ .Values.global.secret }}-idds-auth
+              - configMap:
+                  name: {{ .Release.Name }}-tnsnames
         - name: {{ include "rest.fullname" . }}-certs
           secret:
               secretName: {{ .Values.global.secret }}-idds-certs

--- a/helm/idds/templates/tnsnames-configmap.yaml
+++ b/helm/idds/templates/tnsnames-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.rest.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-tnsnames
+data:
+  tnsnames.ora: |-
+{{ .Files.Get "tnsnames.ora" | indent 4 }}
+{{- end }}

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -13,15 +13,6 @@ rest:
       cpu: "4"
       memory: 6Gi
 
-postgres:
-  resources:
-    requests:
-      cpu: "500m"
-      memory: 1Gi
-    limits:
-      cpu: "2"
-      memory: 4Gi
-
   ingress:
     enabled: true
     hosts:
@@ -35,3 +26,6 @@ postgres:
         hosts:
           - domain: cern.ch
             hostOverride: panda-idds-tb.cern.ch
+
+postgres:
+  enabled: false

--- a/secrets/templates/idds.yaml
+++ b/secrets/templates/idds.yaml
@@ -5,6 +5,10 @@
 {{- $client_vos = append $client_vos $client.name -}}
 {{- end }}
 
+{{- $iddsDbBackend := .Values.idds.database.backend | default "postgres" }}
+{{- $iddsDbHost := .Values.idds.database.dbhost | default .Values.idds.database.host | default (printf "%s-postgres" (include "idds_ref" .)) }}
+{{- $iddsDbPort := .Values.idds.database.port | default "5432" | toString }}
+
 # iDDS configuration
 apiVersion: v1
 kind: Secret
@@ -12,7 +16,7 @@ metadata:
   name: {{ include "secrets.fullname" . }}-idds-db-envs
 type: Opaque
 stringData:
-  IDDS_DB_BACKEND: "{{ .Values.idds.database.backend | default "postgres" }}"
+  IDDS_DB_BACKEND: "{{ $iddsDbBackend }}"
   IDDS_DB: "{{ .Values.idds.database.name }}"
   IDDS_USER: "{{ .Values.idds.database.user }}"
   IDDS_PASSWORD: "{{ .Values.idds.database.password }}"
@@ -42,8 +46,16 @@ stringData:
   IDDS_DATABASE_PASSWORD: "{{ .Values.idds.database.password}}"
   IDDS_DATABASE_SCHEMA: "{{ .Values.idds.database.schema}}"
 
-  IDDS_DATABASE_HOST: "{{ .Values.idds.database.host | default (printf "%s-postgres" (include "idds_ref" .)) }}"
-  IDDS_DATABASE_PORT: "{{ .Values.idds.database.port | default 5432}}"
+  {{- if eq $iddsDbBackend "oracle" }}
+  TNS_ADMIN: "/opt/idds/configmap"
+  IDDS_DATABASE_HOST: "{{ $iddsDbHost }}"
+  IDDS_DATABASE_PORT: ""
+  IDDS_DATABASE_URL: "oracle+oracledb://{{ .Values.idds.database.user }}:{{ .Values.idds.database.password }}@{{ $iddsDbHost }}"
+  {{- else }}
+  IDDS_DATABASE_HOST: "{{ $iddsDbHost }}"
+  IDDS_DATABASE_PORT: "{{ $iddsDbPort }}"
+  IDDS_DATABASE_URL: "postgresql://{{ .Values.idds.database.user }}:{{ .Values.idds.database.password }}@{{ $iddsDbHost }}:{{ $iddsDbPort }}/{{ .Values.idds.database.name }}?keepalives=1&keepalives_idle=30&keepalives_interval=5&keepalives_count=5"
+  {{- end }}
 
   IDDS_CONDUCTOR_BROKERS: "{{ include "msgsvc_ref" . }}-activemq:61613"
   IDDS_CONDUCTOR_PORT: "61613"

--- a/secrets/values.yaml
+++ b/secrets/values.yaml
@@ -123,11 +123,12 @@ idds:
   restPort: 8443
 
   database:
+    backend: "postgres" # or oracle
     name: "idds_db"
     user: "idds"
     password: "FIXME"
     schema: "doma_idds"
-    # set hostname only when using an external database
+    # set hostname/TNS alias only when using an external database (use dbhost for TNS aliases)
     host: ""
     port: "5432"
 


### PR DESCRIPTION
## Summary

- **Disable postgres subchart** for atlas_testbed (`postgres.enabled: false`) — idds uses Oracle, not an in-cluster Postgres
- **Fix ingress hostname**: `ingress:` block was nested under `postgres:` instead of `rest:`, causing the hostname to fall back to `panda-idds-rest.cern.ch` instead of `panda-idds-tb.cern.ch`
- **Oracle connectivity in secrets**: `IDDS_DATABASE_URL` set to `oracle+oracledb://user:pass@TNS_ALIAS` when backend is oracle; supports `dbhost` field (TNS alias lookup); adds `TNS_ADMIN=/opt/idds/configmap`
- **tnsnames.ora ConfigMap**: new `helm/idds/templates/tnsnames-configmap.yaml` exposes the chart-level `tnsnames.ora` into the pod at `/opt/idds/configmap/tnsnames.ora` (where `TNS_ADMIN` points)
- **Skip pg_isready for Oracle**: startup no longer loops on `pg_isready` when `IDDS_DB_BACKEND=oracle`; adds `idds-db-envs` secretRef so the env var is available
- **DB URL in configmap.json**: `${IDDS_DATABASE_URL}` replaces the hardcoded `postgresql://...` connection string, making it work for both backends

## Test plan

- [ ] Upgrade `secrets` helm release — verify `panda-secrets-idds-envs` has `TNS_ADMIN`, `IDDS_DATABASE_URL=oracle+oracledb://...`, no postgres host default
- [ ] Upgrade `panda-idds` — verify postgres pod/service/replicaset are gone
- [ ] Check idds rest pod starts without pg_isready loop
- [ ] Verify ingress hostname is `panda-idds-tb.cern.ch`
- [ ] Confirm idds connects to Oracle (check pod logs for DB connection errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)