### PR TITLE
fix(server): add missing schemaDEFT config

### DIFF
--- a/helm/panda/charts/server/panda_server_config.json
+++ b/helm/panda/charts/server/panda_server_config.json
@@ -12,6 +12,7 @@
         "schemaMETA": "$PANDA_DB_SCHEMAMETA",
         "schemaPANDAARCH": "$PANDA_DB_SCHEMAPANDAARCH",
         "schemaJEDI": "$PANDA_DB_SCHEMAJEDI",
+        "schemaDEFT": "$PANDA_DB_SCHEMADEFT",
         "configurator_use_cert": "False",
         "production_dns": "iddssv1,Robot,Pilot",
 	"pilot_owners": "pilot",


### PR DESCRIPTION
## Summary

- `schemaDEFT` was missing from `panda_server_config.json`, unlike the JEDI config which already had it
- Without it, the server falls back to the hardcoded default `ATLAS_DEFT` instead of the environment-specific value (e.g. `ATLAS_DEFT_TB` for testbed)
- This caused task submission to fail with `ORA-00942: table or view does not exist` when querying `T_TASK` for duplicate task detection

## Test plan

- [ ] Redeploy the server pod and verify task submission succeeds
- [ ] Confirm `PANDA_DB_SCHEMADEFT` env var resolves correctly in the pod