### PR TITLE
bump(panda): server and jedi to 0.7.2, postgres to 0.1.3

### DIFF
--- a/helm/panda/values.yaml
+++ b/helm/panda/values.yaml
@@ -11,7 +11,7 @@ jedi:
 
   # container image and tag
   image:
-    tag: "0.6.12"
+    tag: "0.7.2"
     # tag: "master"
 
   # PV with selector support
@@ -32,7 +32,7 @@ server:
 
   # container image and tag
   image:
-    tag: "0.6.12"
+    tag: "0.7.2"
     # tag: "master"
 
   # PV with selector support
@@ -94,7 +94,7 @@ postgres:
 
   # container image and tag
   image:
-    tag: "0.0.45"
+    tag: "0.1.3"
     #tag: "main"
 
   # PV with selector support


### PR DESCRIPTION
## Summary
- Bump PanDA server image: 0.6.12 → 0.7.2
- Bump JEDI image: 0.6.12 → 0.7.2
- Bump PostgreSQL image: 0.0.45 → 0.1.3