### PR TITLE
feat(atlas-testbed): add ATLAS-specific server and jedi config files

### DIFF
--- a/helm/panda/charts/jedi/panda_jedi_config.atlas_testbed.json
+++ b/helm/panda/charts/jedi/panda_jedi_config.atlas_testbed.json
@@ -1,0 +1,89 @@
+{
+  "db": {
+    "backend": "$PANDA_DB_BACKEND",
+    "dbhost": "$PANDA_DB_HOST",
+    "dbport": "$PANDA_DB_PORT",
+    "dbpasswd": "$PANDA_DB_PASSWORD",
+    "dbuser": "$PANDA_DB_USER",
+    "dbname": "$PANDA_DB_NAME",
+    "schemaJEDI": "$PANDA_DB_SCHEMAJEDI",
+    "schemaDEFT": "$PANDA_DB_SCHEMADEFT",
+    "schemaPANDA": "$PANDA_DB_SCHEMAPANDA",
+    "schemaPANDAARCH": "$PANDA_DB_SCHEMAPANDAARCH",
+    "schemaMETA": "$PANDA_DB_SCHEMAMETA",
+    "nWorkers": "8"
+  },
+  "ddm": {
+    "modConfig": "atlas:6:pandajedi.jediddm.AtlasDDMClient:AtlasDDMClient",
+    "endpoints_json_path": "$PANDA_CRIC_URL_DDMENDPOINTS",
+    "voWithScope": "atlas"
+  },
+  "confeeder": {
+    "procConfig": ":managed|test|ptest|rc_test2:1;:user:1",
+    "nWorkers": "5",
+    "loopCycle": "20"
+  },
+  "postprocessor": {
+    "modConfig": "atlas:any:pandajedi.jedipprocess.AtlasProdPostProcessor:AtlasProdPostProcessor,atlas:user:pandajedi.jedipprocess.AtlasAnalPostProcessor:AtlasAnalPostProcessor",
+    "procConfig": ":managed|test|ptest|rc_test2:1;:user:1",
+    "nWorkers": "5",
+    "nTasks": "500",
+    "loopCycle": "20"
+  },
+  "watchdog": {
+    "modConfig": "atlas:any:pandajedi.jedidog.AtlasProdWatchDog:AtlasProdWatchDog,atlas:user:pandajedi.jedidog.AtlasAnalWatchDog:AtlasAnalWatchDog,atlas:managed:pandajedi.jedidog.AtlasDataLocalityUpdaterWatchDog:AtlasDataLocalityUpdaterWatchDog:DataLocalityUpdater,atlas:managed:pandajedi.jedidog.AtlasTaskWithholderWatchDog:AtlasTaskWithholderWatchDog:TaskWithholder,atlas:managed:pandajedi.jedidog.AtlasQueueFillerWatchDog:AtlasQueueFillerWatchDog:QueueFiller,atlas:user:pandajedi.jedidog.AtlasDataCarouselWatchDog:AtlasDataCarouselWatchDog:DataCarouselWatchDog",
+    "procConfig": "atlas:any:1;atlas:user:1:AtlasAnalWatchDog:60;atlas:managed:1:DataLocalityUpdater:43200;atlas:managed:1:TaskWithholder:300;atlas:managed:1:QueueFiller:600;atlas:user:1:DataCarouselWatchDog:300",
+    "loopCycle": "300",
+    "waitForPicked": "30",
+    "waitForPending": "20",
+    "timeoutForPending": "1",
+    "timeoutForPendingVoLabel": "atlas:managed:120",
+    "waitForLocked": "60",
+    "waitForThrottled": "120",
+    "waitForExhausted": "240",
+    "waitForAchieved": "60"
+  },
+  "taskbroker": {
+    "modConfig": "atlas:any:pandajedi.jedibrokerage.AtlasProdTaskBroker:AtlasProdTaskBroker",
+    "procConfig": "atlas:managed|test:1",
+    "nWorkers": "1",
+    "loopCycle": "60"
+  },
+  "tcommando": {
+    "procConfig": "::1",
+    "nWorkers": "5",
+    "loopCycle": "60"
+  },
+  "taskgen": {
+    "modConfig": "atlas:managed|test:pandajedi.jedigen.AtlasTaskGenerator:AtlasTaskGenerator"
+  },
+  "taskrefine": {
+    "modConfig": "atlas:any:pandajedi.jedirefine.AtlasProdTaskRefiner:AtlasProdTaskRefiner:any,atlas:user:pandajedi.jedirefine.AtlasAnalTaskRefiner:AtlasAnalTaskRefiner:any"
+  },
+  "jobbroker": {
+    "modConfig": "atlas:any:pandajedi.jedibrokerage.AtlasProdJobBroker:AtlasProdJobBroker,atlas:user:pandajedi.jedibrokerage.AtlasAnalJobBroker:AtlasAnalJobBroker"
+  },
+  "jobthrottle": {
+    "modConfig": "atlas:any:pandajedi.jedithrottle.AtlasProdJobThrottler:AtlasProdJobThrottler,atlas:user:pandajedi.jedithrottle.AtlasAnalJobThrottler:AtlasAnalJobThrottler"
+  },
+  "jobgen": {
+    "procConfig": "atlas:managed:2:WORLD:180;atlas:test:2:WORLD:180;atlas:ptest:2:WORLD:180;atlas:rc_test2:2:WORLD:180;atlas:user:1:any:180",
+    "nTasks": "40",
+    "nFiles": "2000",
+    "nFilesPerGroup": "atlas:managed:::1000",
+    "nTasksPerGroup": "atlas:managed:group::200,atlas:managed:group_data::200",
+    "nWorkers": "5",
+    "loopCycle": "30",
+    "typicalNumFile": ":::logmerge:1000000",
+    "lockProcess": "atlas:managed::;atlas:test::"
+  },
+  "tasksetup": {
+    "modConfig": "atlas:any:pandajedi.jedisetup.AtlasTaskSetupper:AtlasTaskSetupper"
+  },
+  "msgprocessor": {
+    "configFile": "/opt/panda/etc/panda/jedi_msg_proc_config.json"
+  },
+  "mq": {
+    "configFile": "/opt/panda/etc/panda/jedi_mq_config.json"
+  }
+}

--- a/helm/panda/charts/jedi/templates/configmap.yaml
+++ b/helm/panda/charts/jedi/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "jedi.fullname" . }}-configjson
 data:
   panda_jedi_config.json: |-
-{{ .Files.Get "panda_jedi_config.json" | indent 4}}
+{{ .Files.Get (.Values.configFile | default "panda_jedi_config.json") | indent 4}}
 
 ---
 # sandbox

--- a/helm/panda/charts/server/panda_server_config.atlas_testbed.json
+++ b/helm/panda/charts/server/panda_server_config.atlas_testbed.json
@@ -1,0 +1,60 @@
+{
+  "server": {
+    "CRIC_URL_CM": "$PANDA_CRIC_CM",
+    "CRIC_URL_DDMBLACKLIST": "$PANDA_CRIC_DDMBLACKLIST",
+    "CRIC_URL_DDMENDPOINTS": "$PANDA_CRIC_DDMENDPOINTS",
+    "CRIC_URL_SCHEDCONFIG": "$PANDA_CRIC_SCHEDCONFIG",
+    "CRIC_URL_SITES": "$PANDA_CRIC_SITES",
+    "backend": "$PANDA_DB_BACKEND",
+    "schemaPANDA": "$PANDA_DB_SCHEMAPANDA",
+    "schemaMETA": "$PANDA_DB_SCHEMAMETA",
+    "schemaPANDAARCH": "$PANDA_DB_SCHEMAPANDAARCH",
+    "schemaJEDI": "$PANDA_DB_SCHEMAJEDI",
+    "schemaDEFT": "$PANDA_DB_SCHEMADEFT",
+    "configurator_use_cert": "False",
+    "pserveralias": "pandaserver-tb.cern.ch",
+    "pserverhost": "$PANDA_HOSTNAME",
+    "pserverport": "443",
+    "pserverportcache": "443",
+    "wn_script_base_url": "https://pandaserver-tb.cern.ch:443",
+    "disableHTTP": "True",
+    "dbhost": "$PANDA_DB_HOST",
+    "dbport": "$PANDA_DB_PORT",
+    "dbpasswd": "$PANDA_DB_PASSWORD",
+    "dbuser": "$PANDA_DB_USER",
+    "dbname": "$PANDA_DB_NAME",
+    "nDBConnection": "1",
+    "usedbtimeout": "True",
+    "dbtimeout": "300",
+    "dbbridgeverbose": "False",
+    "dump_sql": "False",
+    "useJEDI": "True",
+    "production_dns": "pandasv,atlpilo,atlact,Robot Pilot,Robot Harvester",
+    "pilot_owners": "/atlas/usatlas/Role=production,/atlas/Role=pilot,ATLAS Pilot1,ATLAS Pilot2,peter love,Andrej Filipcic,usathpc",
+    "adder_plugins": "local:dataservice.AdderDummyPlugin:AdderDummyPlugin",
+    "setupper_plugins": "local:dataservice.SetupperDummyPlugin:SetupperDummyPlugin",
+    "closer_plugins": "atlas:dataservice.closer_atlas_plugin:CloserAtlasPlugin",
+    "token_authType": "oidc",
+    "sandboxHostname": "$PANDA_HOSTNAME",
+    "mq_configFile": "/opt/panda/etc/panda/panda_mbproxy_config.json",
+    "cache_dir": "/var/log/panda/pandacache/",
+    "token_cache_config": "/data/panda/token_cache_config.json"
+  },
+  "daemon": {
+    "enable": "True",
+    "uname": "atlpan",
+    "gname": "zp",
+    "package": "pandaserver.daemons.scripts",
+    "n_proc": "8",
+    "proc_lifetime": "172800",
+    "n_dbconn": "1",
+    "config": {
+      "configurator": {
+        "enable": true,
+        "module": "configurator",
+        "period": 200,
+        "sync": true
+      }
+    }
+  }
+}

--- a/helm/panda/charts/server/templates/configmap.yaml
+++ b/helm/panda/charts/server/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "server.fullname" . }}-configjson
 data:
   panda_server_config.json: |-
-{{ .Files.Get "panda_server_config.json" | indent 4}}
+{{ .Files.Get (.Values.configFile | default "panda_server_config.json") | indent 4}}
 
 ---
 # server env variables

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 server:
+  configFile: panda_server_config.atlas_testbed.json
   resources:
     requests:
       cpu: "1"
@@ -30,6 +31,7 @@ server:
             hostOverride: pandaserver-tb.cern.ch
 
 jedi:
+  configFile: panda_jedi_config.atlas_testbed.json
   resources:
     requests:
       cpu: "1"


### PR DESCRIPTION
## Summary

- Add `panda_server_config.atlas_testbed.json` and `panda_jedi_config.atlas_testbed.json` with ATLAS-specific plugin configuration (closer, DDM client, brokerage, watchdog, post-processor, etc.) instead of the generic wlcg ones
- Update `configmap.yaml` templates for server and jedi to support a selectable config file via `.Values.configFile`, defaulting to the existing generic config — no impact on other deployments
- Set `configFile` in `values-atlas_testbed.yaml` to point to the new ATLAS-specific files

## Test plan

- [ ] Redeploy panda server and jedi in the ATLAS testbed and verify the correct config is mounted
- [ ] Confirm other deployments (DOMA, LSST, etc.) are unaffected (default config used when `configFile` is not set)