### PR TITLE
bump(bigmon): update docker image tag to v0.7.7

### DIFF
--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -12,8 +12,8 @@ main:
   enabled: true
 
   image:
-    tag: "v0.7.3"
-    # tag: "v0.7.1"
+    tag: "v0.7.7"
+    # tag: "v0.7.3"
 
   autoStart: true
 


### PR DESCRIPTION
## Summary
- Bump bigmon docker image tag from `v0.7.3` to `v0.7.7` in `helm/bigmon/values.yaml`

## Test plan
- [ ] Verify bigmon deploys correctly with the new image tag