### PR TITLE
bump(bigmon): update docker image tag to v0.7.8

### DIFF
--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -12,8 +12,8 @@ main:
   enabled: true
 
   image:
-    tag: "v0.7.7"
-    # tag: "v0.7.3"
+    tag: "v0.7.8"
+    # tag: "v0.7.7"
 
   autoStart: true
 


### PR DESCRIPTION
## Summary
- Bump bigmon docker image tag from `v0.7.7` to `v0.7.8`
- v0.7.8 pins `oracledb==2.0.1` to fix incompatibility with Django 5.0.8 (oracledb 3.x broke DB connections with `TypeError: isinstance() arg 2 must be a type`)

## Test plan
- [ ] Verify bigmon deploys and task pages load without 500 errors