### PR TITLE
fix(rucio): support x509_proxy auth type in rucio.cfg template

### DIFF
--- a/helm/panda/sandbox/rucio.cfg.template
+++ b/helm/panda/sandbox/rucio.cfg.template
@@ -6,10 +6,11 @@ logformat = %%(asctime)s\t%%(process)d\t%%(levelname)s\t%%(message)s
 [client]
 rucio_host = https://${PANDA_RUCIO_HOST}
 auth_host = https://${PANDA_RUCIO_AUTH_HOST}
-auth_type = userpass
+auth_type = ${PANDA_RUCIO_AUTH_TYPE}
 username = ${PANDA_RUCIO_USERNAME}
 password = ${PANDA_RUCIO_PASSWORD}
-ca_cert = /etc/grid-security/certificates/
+client_x509_proxy = ${PANDA_RUCIO_X509_PROXY}
+ca_cert = ${PANDA_RUCIO_CA_CERT}
 account = ${PANDA_RUCIO_ACCOUNT}
 request_retries = 3
 protocol_stat_retries = 6

--- a/secrets/templates/panda.yaml
+++ b/secrets/templates/panda.yaml
@@ -58,9 +58,14 @@ stringData:
   PANDA_RUCIO_AUTH_TYPE: "x509_proxy"
   PANDA_RUCIO_X509_PROXY: "{{ .Values.rucio.clientX509Proxy }}"
   PANDA_RUCIO_CA_CERT: "{{ .Values.rucio.caCert }}"
+  PANDA_RUCIO_USERNAME: ""
+  PANDA_RUCIO_PASSWORD: ""
   {{- else if eq (.Values.rucio.authType | default "userpass") "oidc" }}
   PANDA_RUCIO_AUTH_TYPE: "oidc"
   PANDA_RUCIO_CA_CERT: "{{ .Values.rucio.caCert }}"
+  PANDA_RUCIO_X509_PROXY: ""
+  PANDA_RUCIO_USERNAME: ""
+  PANDA_RUCIO_PASSWORD: ""
   PANDA_RUCIO_OIDC_AUDIENCE: "{{ .Values.rucio.oidcAudience | default "rucio" }}"
   PANDA_RUCIO_OIDC_SCOPE: "{{ .Values.rucio.oidcScope | default "openid profile offline_access" }}"
   PANDA_RUCIO_OIDC_ISSUER: "{{ .Values.rucio.oidcIssuer | default "wlcg" }}"
@@ -70,6 +75,8 @@ stringData:
   PANDA_RUCIO_AUTH_TYPE: "userpass"
   PANDA_RUCIO_USERNAME: "{{ .Values.rucio.username }}"
   PANDA_RUCIO_PASSWORD: "{{ .Values.rucio.password }}"
+  PANDA_RUCIO_X509_PROXY: ""
+  PANDA_RUCIO_CA_CERT: "/etc/grid-security/certificates/"
   {{- end }}
 
   # CRIC


### PR DESCRIPTION
## Summary
- `rucio.cfg.template` hardcoded `auth_type = userpass`, ignoring the `PANDA_RUCIO_AUTH_TYPE` env var — deployments using `x509_proxy` were silently falling back to userpass and failing with `CannotAuthenticate`
- Updated template to use `${PANDA_RUCIO_AUTH_TYPE}`, `${PANDA_RUCIO_X509_PROXY}`, and `${PANDA_RUCIO_CA_CERT}`
- Updated `secrets/templates/panda.yaml` to always set all three env vars in every auth branch (with empty or sensible defaults) so envsubst never leaves unresolved placeholders

## Test plan
- [ ] Verify rucio.cfg in panda pod has correct `auth_type = x509_proxy` after secrets re-apply
- [ ] Verify task brokerage no longer fails with `CannotAuthenticate`