### PR TITLE
fix(jedi): mount panda-certs secret to provide x509 proxy for Rucio auth

### DIFF
--- a/helm/panda/charts/jedi/templates/statefulset.yaml
+++ b/helm/panda/charts/jedi/templates/statefulset.yaml
@@ -105,6 +105,8 @@ spec:
                 mountPath: /opt/panda/etc/config_json
               - name: {{ include "jedi.fullname" . }}-sandbox
                 mountPath: /opt/panda/sandbox
+              - name: {{ include "jedi.fullname" . }}-certs
+                mountPath: /opt/panda/etc/cert
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-server-env
@@ -127,6 +129,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: {{ include "jedi.fullname" . }}-certs
+          secret:
+              secretName: {{ .Values.global.secret }}-panda-certs
         - name: {{ include "jedi.fullname" . }}-sandbox
           projected:
             sources:


### PR DESCRIPTION
## Summary
- Jedi pod was missing the `panda-certs` secret mount at `/opt/panda/etc/cert`
- The server pod has this mount (providing `panda_latest_x509.proxy`), but Jedi did not
- Without this, Rucio x509_proxy auth in Jedi fails with "Cannot find a valid X509 proxy"

## Test plan
- [ ] Verify `/opt/panda/etc/cert/panda_latest_x509.proxy` exists in `panda-jedi-0` after redeploy
- [ ] Verify task brokerage no longer fails with x509 proxy error