### PR TITLE
bump(bigmon): update docker image tag to v0.7.10

### DIFF
--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -12,8 +12,7 @@ main:
   enabled: true
 
   image:
-    tag: "v0.7.6"
-    # tag: "v0.7.8"
+    tag: "v0.7.10"
 
   autoStart: true
 


### PR DESCRIPTION
## Summary
- Update bigpandmon docker image tag from v0.7.6 to v0.7.10 in `helm/bigmon/values.yaml`

## Test plan
- [ ] Deploy bigmon with the new image tag and verify it starts correctly