### PR TITLE
fix(atlas_testbed): add ssl-passthrough annotation for x509/GRID proxy cert support

### DIFF
--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -18,6 +18,8 @@ server:
     enabled: false
   ingress:
     enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     hosts:
       - domain: cern.ch
         hostOverride: pandaserver-tb.cern.ch


### PR DESCRIPTION
## Summary
- Add `nginx.ingress.kubernetes.io/ssl-passthrough: "true"` to the atlas_testbed panda-server ingress values
- Required for x509/GRID proxy certificate authentication: GRID proxy certs use a non-standard X.509 chain (`CA:FALSE`) that nginx cannot verify with standard SSL termination. SSL passthrough forwards raw TCP directly to Apache, which handles the full SSL handshake via `mod_gridsite`.

## Test plan
- [ ] ArgoCD sync applies the annotation to the panda-server ingress
- [ ] prun sandbox upload succeeds with x509 proxy certificate