### PR TITLE
fix(harvester): use PANDA_API_URL_SSL for server_api_url_ssl

### DIFF
--- a/helm/harvester/charts/harvester/panda_harvester_configmap.json
+++ b/helm/harvester/charts/harvester/panda_harvester_configmap.json
@@ -27,7 +27,7 @@
     "pandaURL": "${PANDA_URL_SSL}",
     "pandaURLSSL": "${PANDA_URL_SSL}",
     "cache_api_url_ssl": "${PANDA_URL_SSL}",
-    "server_api_url_ssl": "${PANDA_URL_SSL}",
+    "server_api_url_ssl": "${PANDA_API_URL_SSL}",
     "verbose": true
   },
   "apfmon": {

--- a/helm/harvester/charts/harvester/panda_harvester_configmap.json
+++ b/helm/harvester/charts/harvester/panda_harvester_configmap.json
@@ -26,7 +26,7 @@
     "auth_origin": "${PANDA_AUTH_VO}",
     "pandaURL": "${PANDA_URL_SSL}",
     "pandaURLSSL": "${PANDA_URL_SSL}",
-    "cache_api_url_ssl": "${PANDA_URL_SSL}",
+    "cache_api_url_ssl": "${PANDA_API_URL_SSL}",
     "server_api_url_ssl": "${PANDA_API_URL_SSL}",
     "verbose": true
   },


### PR DESCRIPTION
## Summary
- `server_api_url_ssl` was set to `${PANDA_URL_SSL}` (`/server/panda`), causing all new REST API calls from Harvester (e.g. `/server/panda/harvester/add_dialogs`) to return 403
- panda-server only routes new-style endpoints under `/api/<version>/<module>/<method>`, not `/server/panda/<module>/<method>`
- `PANDA_API_URL_SSL` already exists as an env var pointing to the correct `/api/v1` base URL

## Test plan
- [ ] ArgoCD syncs and redeploys Harvester with updated configmap
- [ ] Harvester API calls to panda-server return 200 instead of 403
- [ ] Harvester submits pilots to CERN queue for activated jobs