### PR TITLE
fix(harvester): add CE token and proxy credential configs for ATLAS

### DIFF
--- a/helm/harvester/charts/harvester/configmap/atlas.panda_harvester_configmap.json
+++ b/helm/harvester/charts/harvester/configmap/atlas.panda_harvester_configmap.json
@@ -1,0 +1,191 @@
+{
+  "db": {
+    "engine": "mariadb",
+    "useMySQLdb": true,
+    "syncMaxWorkerID": true,
+    "schema": "${MARIADB_DATABASE}",
+    "host": "${HARVESTER_DB_HOST}",
+    "password": "${MARIADB_PASSWORD}",
+    "verbose": true
+  },
+  "master": {
+    "gname": "zp",
+    "harvester_id": "${HARVESTER_ID}",
+    "uname": "atlpan"
+  },
+  "communicator": {
+    "nConnections": 10
+  },
+  "credmanager": {
+    "moduleName": [],
+    "pluginConfigs": [
+      {
+        "module": "pandaharvester.harvestercredmanager.iam_token_cred_manager",
+        "name": "IamTokenCredManager",
+        "configs": {
+          "atlas-pilot": {
+            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-atlas_testbed_pilot.json",
+            "target_type": "common",
+            "out_dir": "/data/tokens/pilot",
+            "target_list": [
+              "pandaserver-tb.cern.ch"
+            ],
+            "check_interval": 1800,
+            "refresh_interval": 3600
+          },
+          "atlas-ce-prod": {
+            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-compute_client_prod.json",
+            "target_type": "ce",
+            "out_dir": "/data/tokens/ce/prod",
+            "check_interval": 1800,
+            "refresh_interval": 85500
+          },
+          "atlas-ce-pilot": {
+            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-compute_client_pilot.json",
+            "target_type": "ce",
+            "out_dir": "/data/tokens/ce/pilot",
+            "check_interval": 1800,
+            "refresh_interval": 85500
+          },
+          "pilot-pandaserver-token": {
+            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-pilot_pandaserver.json",
+            "target_type": "panda",
+            "panda_token_filename": "panda_token",
+            "out_dir": "/data/tokens/pandaserver",
+            "check_interval": 1800,
+            "refresh_interval": 3500
+          },
+          "harvester-pandaserver-token": {
+            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-harvester_pandaserver.json",
+            "target_type": "panda",
+            "panda_token_filename": "harvester_panda_token",
+            "out_dir": "/data/tokens/harvester_pandaserver",
+            "check_interval": 900,
+            "refresh_interval": 1700
+          }
+        }
+      },
+      {
+        "module": "pandaharvester.harvestercredmanager.token_key_cred_manager",
+        "name": "TokenKeyCredManager",
+        "configs": {
+          "pilot-panda-token-key": {
+            "token_key_file": "/opt/harvester/etc/auth/panda_token_key",
+            "client_name": "Rubin.production"
+          }
+        }
+      },
+      {
+        "module": "pandaharvester.harvestercredmanager.no_voms_cred_manager",
+        "name": "NoVomsCredManager",
+        "configs": {
+          "production": {
+            "inCertFile": "/data/harvester/run/atlpilo1RFC.plain",
+            "outCertFile": "/data/harvester/run/x509up_u25606_prod",
+            "voms": "atlas:/atlas/Role=production"
+          },
+          "pilot": {
+            "inCertFile": "/data/harvester/run/atlpilo1RFC.plain",
+            "outCertFile": "/data/harvester/run/x509up_u25606_pilot",
+            "voms": "atlas:/atlas/Role=pilot"
+          }
+        }
+      }
+    ],
+    "sleepTime": 1800
+  },
+  "payload_interaction": {
+    "jobSpecFile": "pandaJobData.out",
+    "workerAttributesFile": "worker_attributes.json",
+    "jobReportFile": "jobReport.json",
+    "jobRequestFile": "worker_requestjob.json",
+    "xmlPoolCatalogFile": "PoolFileCatalog_H.xml",
+    "pandaIDsFile": "worker_pandaids.json",
+    "killWorkerFile": "kill_worker.json",
+    "heartbeatFile": "worker_heartbeat.json"
+  },
+  "pandacon": {
+    "ca_cert": false,
+    "auth_type": "oidc",
+    "auth_token": "${PANDA_AUTH_ID_TOKEN}",
+    "auth_origin": "${PANDA_AUTH_VO}",
+    "pandaURL": "${PANDA_URL_SSL}",
+    "pandaURLSSL": "${PANDA_URL_SSL}",
+    "cache_api_url_ssl": "${PANDA_API_URL_SSL}",
+    "server_api_url_ssl": "${PANDA_API_URL_SSL}",
+    "verbose": true
+  },
+  "apfmon": {
+    "active": true,
+    "base_url": "https://rtmon.lancs.ac.uk/api"
+  },
+  "frontend": {
+    "type": "apache"
+  },
+  "jobfetcher": {
+    "lookupTime": 30,
+    "sleepTime": 10
+  },
+  "propagator": {
+    "maxJobs": 1000,
+    "maxWorkers": 1000,
+    "nWorkersInBulk": 100,
+    "sleepTime": 5
+  },
+  "preparator": {
+    "nThreads": 5,
+    "maxJobsToCheck": 1000,
+    "maxJobsToTrigger": 1000,
+    "checkInterval": 15,
+    "triggerInterval": 10,
+    "sleepTime": 10
+  },
+  "submitter": {
+    "nThreads": 5,
+    "nQueues": 30,
+    "lookupTime": 30,
+    "maxNewWorkers": 1000,
+    "checkInterval": 30,
+    "sleepTime": 10,
+    "activateWorkerFactor": "auto"
+  },
+  "monitor": {
+    "nThreads": 10,
+    "checkInterval": 30,
+    "lookupTime": 30,
+    "sleepTime": 10
+  },
+  "stager": {
+    "nThreads": 5,
+    "maxJobsToCheck": 1000,
+    "maxJobsToTrigger": 1000,
+    "maxJobsToZip": 1000,
+    "checkInterval": 180,
+    "triggerInterval": 180,
+    "sleepTime": 60
+  },
+  "watcher": {
+    "checkInterval": 30,
+    "sleepTime": 30
+  },
+  "service_monitor": {
+    "pidfile": "/var/run/panda/panda_harvester.pid"
+  },
+  "qconf": {
+    "configFile": "/opt/harvester/etc/panda/panda_queueconfig.json",
+    "queueList": [
+      "ALL"
+    ]
+  },
+  "cacher": {
+    "refreshInterval": 1,
+    "data": [
+      "resource_types.json||panda_server:get_resource_types",
+      "job_statistics.json||panda_server:get_job_stats",
+      "worker_statistics.json||panda_server:get_worker_stats_from_panda",
+      "ddmendpoints_objectstores.json||$HARVESTER_CRIC_OS",
+      "panda_queues.json||$HARVESTER_CRIC_SCHEDCONFIG",
+      "agis_ddmendpoints.json||$HARVESTER_CRIC_DDMENDPOINTS"
+    ]
+  }
+}

--- a/helm/harvester/charts/harvester/panda_harvester_configmap.json
+++ b/helm/harvester/charts/harvester/panda_harvester_configmap.json
@@ -114,31 +114,6 @@
             "target_type": "common",
             "target_list": ["https://pandaserver-doma.cern.ch:25443"],
             "out_dir": "/opt/harvester/etc/auth_tokens/"
-          },
-          "ce-pilot": {
-            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-compute_client_pilot.json",
-            "target_type": "ce",
-            "out_dir": "/data/tokens/ce/pilot",
-            "check_interval": 1800,
-            "refresh_interval": 85500
-          },
-          "pilot-pandaserver-token": {
-            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-pilot_pandaserver.json",
-            "target_type": "panda",
-            "panda_token_filename": "panda_token",
-            "out_dir": "/data/tokens/pandaserver",
-            "check_interval": 1800,
-            "refresh_interval": 3500
-          }
-        }
-      },
-      {
-        "module": "pandaharvester.harvestercredmanager.no_voms_cred_manager",
-        "name": "NoVomsCredManager",
-        "configs": {
-          "pilot": {
-            "inCertFile": "/data/harvester/run/atlpilo1RFC.plain",
-            "outCertFile": "/data/harvester/run/x509up_u25606_pilot"
           }
         }
       }

--- a/helm/harvester/charts/harvester/panda_harvester_configmap.json
+++ b/helm/harvester/charts/harvester/panda_harvester_configmap.json
@@ -114,6 +114,31 @@
             "target_type": "common",
             "target_list": ["https://pandaserver-doma.cern.ch:25443"],
             "out_dir": "/opt/harvester/etc/auth_tokens/"
+          },
+          "ce-pilot": {
+            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-compute_client_pilot.json",
+            "target_type": "ce",
+            "out_dir": "/data/tokens/ce/pilot",
+            "check_interval": 1800,
+            "refresh_interval": 85500
+          },
+          "pilot-pandaserver-token": {
+            "client_cred_file": "/opt/harvester/etc/auth/token_harvester-pilot_pandaserver.json",
+            "target_type": "panda",
+            "panda_token_filename": "panda_token",
+            "out_dir": "/data/tokens/pandaserver",
+            "check_interval": 1800,
+            "refresh_interval": 3500
+          }
+        }
+      },
+      {
+        "module": "pandaharvester.harvestercredmanager.no_voms_cred_manager",
+        "name": "NoVomsCredManager",
+        "configs": {
+          "pilot": {
+            "inCertFile": "/data/harvester/run/atlpilo1RFC.plain",
+            "outCertFile": "/data/harvester/run/x509up_u25606_pilot"
           }
         }
       }

--- a/helm/harvester/charts/harvester/sandbox/atlas.init-harvester
+++ b/helm/harvester/charts/harvester/sandbox/atlas.init-harvester
@@ -5,6 +5,9 @@ mkdir /data/harvester/run
 cp /opt/harvester/etc/auth/atlpilo1RFC.plain /data/harvester/run/atlpilo1RFC.plain
 chmod 600 /data/harvester/run/atlpilo1RFC.plain
 
+# create token directories for IamTokenCredManager
+mkdir -p /data/tokens/ce/pilot /data/tokens/ce/prod /data/tokens/pandaserver
+
 # vomses file to refer to the atlas VOMS server
 echo '"atlas" "voms-atlas-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=atlas-auth.cern.ch" "atlas" "24"' >> /etc/vomses
 

--- a/helm/harvester/charts/harvester/sandbox/init-harvester
+++ b/helm/harvester/charts/harvester/sandbox/init-harvester
@@ -24,6 +24,11 @@ if [[ ! -f /opt/harvester/etc/queue_config/panda_queueconfig.json ]]; then
     fi
 fi
 
+# use experiment-specific harvester configmap if available
+if [[ ! -z "${EXPERIMENT}" ]] && [[ -f /opt/harvester/etc/configmap/${EXPERIMENT}.panda_harvester_configmap.json ]]; then
+    ln -sf /opt/harvester/etc/configmap/${EXPERIMENT}.panda_harvester_configmap.json /opt/harvester/etc/panda/panda_harvester_configmap.json
+fi
+
 if [[ ! -z "${EXPERIMENT}" ]]; then
     echo "init experiment ${EXPERIMENT}"
     CurrentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/helm/harvester/charts/harvester/templates/configmap.yaml
+++ b/helm/harvester/charts/harvester/templates/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
 data:
   panda_harvester_configmap.json: |-
 {{ .Files.Get "panda_harvester_configmap.json" | indent 4}}
+{{- range $path, $_ := .Files.Glob "configmap/*" }}
+  {{ base $path }}: |-
+{{ $.Files.Get $path | indent 4}}
+{{- end }}
 ---
 # queue config
 apiVersion: v1


### PR DESCRIPTION
## Summary

- Add `IamTokenCredManager` configs for CE pilot bearer tokens (`token_harvester-compute_client_pilot.json` → `/data/tokens/ce/pilot`) and pilot-to-PanDA tokens (`token_harvester-pilot_pandaserver.json` → `/data/tokens/pandaserver`)
- Add `NoVomsCredManager` plugin to copy `atlpilo1RFC.plain` to the expected `x509UserProxy` path so HTCondorSubmitter has a valid proxy for GSI SSL auth to CERN CEs
- Create token directories in `atlas.init-harvester` so they exist before IamTokenCredManager first tries to write tokens

## Problem

HTCondorSubmitter was silently skipping all pilot submissions because neither the x509 proxy (`/data/harvester/run/x509up_u25606_pilot`) nor the CE token directory (`/data/tokens/ce/pilot`) existed. The `atlas.submit_pilot.sdf` requires both `x509userproxy` (for GSI connection) and `+ScitokensFile` (for authorization).

## Test plan
- [ ] After ArgoCD syncs and pod restarts, verify `/data/harvester/run/x509up_u25606_pilot` exists
- [ ] Verify `/data/tokens/ce/pilot/` is populated with bearer tokens
- [ ] Verify `panda-htcondor_submitter.log` shows actual submission attempts after `submit_workers start`
- [ ] Verify pilots appear at CERN CE