### PR TITLE
feat(harvester): support experiment-specific harvester configmap

### DIFF
--- a/helm/harvester/charts/harvester/sandbox/init-harvester
+++ b/helm/harvester/charts/harvester/sandbox/init-harvester
@@ -24,11 +24,6 @@ if [[ ! -f /opt/harvester/etc/queue_config/panda_queueconfig.json ]]; then
     fi
 fi
 
-# use experiment-specific harvester configmap if available
-if [[ ! -z "${EXPERIMENT}" ]] && [[ -f /opt/harvester/etc/configmap/${EXPERIMENT}.panda_harvester_configmap.json ]]; then
-    ln -sf /opt/harvester/etc/configmap/${EXPERIMENT}.panda_harvester_configmap.json /opt/harvester/etc/panda/panda_harvester_configmap.json
-fi
-
 if [[ ! -z "${EXPERIMENT}" ]]; then
     echo "init experiment ${EXPERIMENT}"
     CurrentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/helm/harvester/charts/harvester/templates/configmap.yaml
+++ b/helm/harvester/charts/harvester/templates/configmap.yaml
@@ -5,10 +5,11 @@ metadata:
   name: {{ include "harvester.fullname" . }}-configjson
 data:
   panda_harvester_configmap.json: |-
+{{- $expCfg := printf "configmap/%s.panda_harvester_configmap.json" (.Values.experiment | default "") }}
+{{- if and .Values.experiment (.Files.Get $expCfg) }}
+{{ .Files.Get $expCfg | indent 4 }}
+{{- else }}
 {{ .Files.Get "panda_harvester_configmap.json" | indent 4}}
-{{- range $path, $_ := .Files.Glob "configmap/*" }}
-  {{ base $path }}: |-
-{{ $.Files.Get $path | indent 4}}
 {{- end }}
 ---
 # queue config

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -1,6 +1,8 @@
 # Default values for harvester - atlas testbed overrides.
 # This is a YAML-formatted file.
 
+experiment: atlas
+
 harvester:
   persistentvolume:
     size: 50Gi


### PR DESCRIPTION
## Summary

Adds support for per-experiment `panda_harvester_configmap.json` overrides, following the same pattern used for queueconfig.

- **`configmap/atlas.panda_harvester_configmap.json`**: Full ATLAS credential manager config with `IamTokenCredManager` (CE pilot/prod tokens, pilot→PanDA tokens, harvester→PanDA tokens), `TokenKeyCredManager`, and `NoVomsCredManager` (copies `atlpilo1RFC.plain` to expected x509 proxy paths — VOMS renewal cron not needed)
- **`templates/configmap.yaml`**: If `experiment` value is set and `configmap/{experiment}.panda_harvester_configmap.json` exists, that file's content is used as the `panda_harvester_configmap.json` ConfigMap key — so pandaharvester (which hardcodes loading `$PANDA_HOME/etc/configmap/panda_harvester_configmap.json`) picks it up automatically
- **`values/values-atlas_testbed.yaml`**: Sets `experiment: atlas`

## Why this approach

pandaharvester hardcodes the config path as `$PANDA_HOME/etc/configmap/panda_harvester_configmap.json`. The ConfigMap volume mount is read-only, so runtime symlinking doesn't work. The fix is at the Helm layer: conditionally populate the `panda_harvester_configmap.json` key with experiment-specific content at deploy time.

Other experiments (LSST, Sphenix) are unaffected — they don't set `experiment` in their values files, so they continue using the generic configmap.

## Test plan
- [ ] Merge and let ArgoCD sync
- [ ] `kubectl rollout restart statefulset/panda-harvester`
- [ ] Verify atlas config active: `kubectl exec panda-harvester-0 -- python3 -c "import json; d=json.load(open('/opt/harvester/etc/configmap/panda_harvester_configmap.json')); print([c['name'] for c in d['credmanager']['pluginConfigs']])"`
- [ ] Verify proxy files created: `kubectl exec panda-harvester-0 -- ls -la /data/harvester/run/x509up_u25606_pilot`
- [ ] Verify CE tokens populated: `kubectl exec panda-harvester-0 -- ls /data/tokens/ce/pilot/`
- [ ] Verify HTCondorSubmitter submits pilots in `panda-htcondor_submitter.log`