### PR TITLE
atlas: disable httpd SSL config on init to fix autostart

### DIFF
--- a/helm/harvester/charts/harvester/sandbox/atlas.init-harvester
+++ b/helm/harvester/charts/harvester/sandbox/atlas.init-harvester
@@ -11,3 +11,8 @@ mkdir -p /data/tokens/pilot /data/tokens/ce/pilot /data/tokens/ce/prod /data/tok
 # vomses file to refer to the atlas VOMS server
 echo '"atlas" "voms-atlas-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=atlas-auth.cern.ch" "atlas" "24"' >> /etc/vomses
 
+# disable httpd SSL config (cert/key mismatch in CERN testbed deployment)
+if [ -f /etc/httpd/conf.d/ssl-httpd.conf ]; then
+    mv /etc/httpd/conf.d/ssl-httpd.conf /etc/httpd/conf.d/ssl-httpd.conf.disabled
+fi
+


### PR DESCRIPTION
## Summary
- `ssl-httpd.conf` has a cert/key mismatch in the CERN testbed deployment, preventing httpd from starting automatically on pod start
- Disables `ssl-httpd.conf` during `atlas.init-harvester` so httpd starts successfully and serves condor logs on port 8080
- Only affects ATLAS deployments; safe since ATLAS harvester is only deployed in k8s for the CERN testbed

## Test plan
- [ ] Merge and ArgoCD sync panda-harvester
- [ ] Delete panda-harvester-0 pod and confirm httpd starts automatically on restart
- [ ] Verify `https://bigpanda-tb.cern.ch/condor_logs/` returns 200