### PR TITLE
atlas_testbed: resource limits, log rotation and CephFS storage

### DIFF
--- a/helm/harvester/charts/harvester/sandbox/logrotate-harvester
+++ b/helm/harvester/charts/harvester/sandbox/logrotate-harvester
@@ -1,5 +1,5 @@
 /var/log/panda/*log {
-    rotate 3
+    rotate 2
     daily
     compress
     missingok

--- a/helm/harvester/charts/harvester/sandbox/logrotate-harvester
+++ b/helm/harvester/charts/harvester/sandbox/logrotate-harvester
@@ -1,5 +1,5 @@
 /var/log/panda/*log {
-    rotate 2
+    rotate 3
     daily
     compress
     missingok

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -28,11 +28,11 @@ harvester:
     size: 50Gi
   resources:
     requests:
-      cpu: "1"
-      memory: 2Gi
+      cpu: "2"
+      memory: 4Gi
     limits:
-      cpu: "4"
-      memory: 6Gi
+      cpu: "6"
+      memory: 8Gi
 
 mariadb:
   resources:

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -21,10 +21,16 @@ harvester:
           - domain: cern.ch
             hostOverride: bigpanda-tb.cern.ch
   persistentvolume:
+    create: false
+    class: manila-meyrin-cephfs
+    selector: false
     size: 50Gi
   persistentvolumewdir:
     size: 50Gi
   persistentvolumecondor:
+    create: false
+    class: manila-meyrin-cephfs
+    selector: false
     size: 50Gi
   resources:
     requests:

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -12,6 +12,9 @@ server:
       cpu: "6"
       memory: 8Gi
   persistentvolume:
+    create: false
+    class: manila-meyrin-cephfs
+    selector: false
     size: 50Gi
   # use Route class for ingress
   route:
@@ -42,6 +45,9 @@ jedi:
       cpu: "6"
       memory: 8Gi
   persistentvolume:
+    create: false
+    class: manila-meyrin-cephfs
+    selector: false
     size: 50Gi
 
 postgres:

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -6,11 +6,11 @@ server:
   configFile: panda_server_config.atlas_testbed.json
   resources:
     requests:
-      cpu: "1"
-      memory: 2Gi
+      cpu: "2"
+      memory: 4Gi
     limits:
-      cpu: "4"
-      memory: 6Gi
+      cpu: "6"
+      memory: 8Gi
   persistentvolume:
     size: 50Gi
   # use Route class for ingress
@@ -36,11 +36,11 @@ jedi:
   configFile: panda_jedi_config.atlas_testbed.json
   resources:
     requests:
-      cpu: "1"
-      memory: 2Gi
+      cpu: "2"
+      memory: 4Gi
     limits:
-      cpu: "4"
-      memory: 6Gi
+      cpu: "6"
+      memory: 8Gi
   persistentvolume:
     size: 50Gi
 


### PR DESCRIPTION
## Summary

A collection of improvements for the ATLAS testbed deployment at CERN.

### Resource limits (server, jedi, harvester)
Increased CPU and memory for panda-server, panda-jedi and panda-harvester to better handle production-like workloads on the testbed:
- requests: `cpu: 1 → 2`, `memory: 2Gi → 4Gi`
- limits: `cpu: 4 → 6`, `memory: 6Gi → 8Gi`

### Log rotation
Reduced panda log retention from 3 to 2 rotated copies to save disk space on the node.

### Switch from hostPath to CephFS storage (`manila-meyrin-cephfs`)

Previously all PVs were hostPath-backed, meaning:
- Storage was tied to the local node disk (only 40G per node)
- Pods had implicit node affinity due to hostPath
- PVC size declarations were not enforced

The new setup uses dynamic provisioning via the `manila-meyrin-cephfs` storage class (CERN CephFS/Manila), which:
- Decouples storage from node disk — no more 40G constraint
- Allows pods to reschedule freely across nodes
- Enforces PVC sizes at the storage backend level
- Supports `ReadWriteMany` access mode

Affected PVCs: `panda-server`, `panda-jedi`, `panda-harvester` (logs), `panda-harvester-condor-logs`, `panda-harvester-wdirs`.

## Deployment notes

After ArgoCD sync, the old hostPath PVCs and PVs must be manually deleted (they will not be pruned automatically due to `Retain` reclaim policy):

```bash
kubectl delete pvc panda-server panda-jedi panda-harvester panda-harvester-condor-logs panda-harvester-wdirs
kubectl delete pv panda-server panda-jedi panda-harvester panda-harvester-condor-logs panda-harvester-wdirs
```

The new CephFS-backed PVCs will be created automatically by the dynamic provisioner on pod startup.

## Test plan
- [ ] Merge and ArgoCD sync panda-panda and panda-harvester
- [ ] Delete old hostPath PVCs/PVs listed above
- [ ] Confirm new PVCs are created and bound via `kubectl get pvc`
- [ ] Confirm pods start successfully and logs are written to the new volumes
- [ ] Confirm `https://bigpanda-tb.cern.ch/condor_logs/` still works