### PR TITLE
atlas_testbed: switch iDDS storage to CephFS, reduce to 1 replica

### DIFF
--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 rest:
-  replicaCount: 2
+  replicaCount: 1
   iddsServer: panda-idds-tb.cern.ch
   resources:
     requests:
@@ -12,6 +12,16 @@ rest:
     limits:
       cpu: "4"
       memory: 6Gi
+  persistentvolume:
+    create: false
+    class: manila-meyrin-cephfs
+    selector: false
+    size: 50Gi
+  persistentvolumerequests:
+    create: false
+    class: manila-meyrin-cephfs
+    selector: false
+    size: 10Gi
 
   ingress:
     enabled: true


### PR DESCRIPTION
## Summary

- Switch iDDS `rest` PVCs from hostPath (`manual`) to CephFS (`manila-meyrin-cephfs`) for node-independent storage
- Increase log PVC from 5Gi to 50Gi (was undersized)
- Reduce `replicaCount` from 2 to 1 (sufficient for testbed workloads)

## Deployment notes

After ArgoCD sync, delete the old hostPath PVCs and PVs manually:

```bash
kubectl delete pvc panda-idds-rest panda-idds-rest-requests idds-rest -n default
kubectl delete pv panda-idds-rest panda-idds-rest-requests idds-rest 2>/dev/null
```

Also delete the iDDS StatefulSet so it can be recreated with the new volumeClaimTemplates (StatefulSet spec is immutable):

```bash
kubectl delete statefulset panda-idds-rest -n default
argocd app sync panda-idds --grpc-web
```

New CephFS-backed PVCs will be provisioned automatically.

## Test plan
- [ ] Merge and follow deployment notes above
- [ ] Confirm new PVCs bound on `manila-meyrin-cephfs`
- [ ] Confirm single iDDS pod running and healthy