### PR TITLE
fix(atlas-testbed): add missing server daemons and align JEDI config with production

### DIFF
--- a/helm/panda/charts/jedi/panda_jedi_config.atlas_testbed.json
+++ b/helm/panda/charts/jedi/panda_jedi_config.atlas_testbed.json
@@ -58,10 +58,12 @@
     "modConfig": "atlas:managed|test:pandajedi.jedigen.AtlasTaskGenerator:AtlasTaskGenerator"
   },
   "taskrefine": {
-    "modConfig": "atlas:any:pandajedi.jedirefine.AtlasProdTaskRefiner:AtlasProdTaskRefiner:any,atlas:user:pandajedi.jedirefine.AtlasAnalTaskRefiner:AtlasAnalTaskRefiner:any"
+    "modConfig": "atlas:any:pandajedi.jedirefine.AtlasProdTaskRefiner:AtlasProdTaskRefiner:any,atlas:user:pandajedi.jedirefine.AtlasAnalTaskRefiner:AtlasAnalTaskRefiner:any",
+    "procConfig": ":managed|test|ptest|rc_test2:1;:user:1"
   },
   "jobbroker": {
-    "modConfig": "atlas:any:pandajedi.jedibrokerage.AtlasProdJobBroker:AtlasProdJobBroker,atlas:user:pandajedi.jedibrokerage.AtlasAnalJobBroker:AtlasAnalJobBroker"
+    "modConfig": "atlas:any:pandajedi.jedibrokerage.AtlasProdJobBroker:AtlasProdJobBroker,atlas:user:pandajedi.jedibrokerage.AtlasAnalJobBroker:AtlasAnalJobBroker",
+    "NW_ACTIVE": "True"
   },
   "jobthrottle": {
     "modConfig": "atlas:any:pandajedi.jedithrottle.AtlasProdJobThrottler:AtlasProdJobThrottler,atlas:user:pandajedi.jedithrottle.AtlasAnalJobThrottler:AtlasAnalJobThrottler"

--- a/helm/panda/charts/server/panda_server_config.atlas_testbed.json
+++ b/helm/panda/charts/server/panda_server_config.atlas_testbed.json
@@ -49,16 +49,73 @@
     "proc_lifetime": "172800",
     "n_dbconn": "1",
     "config": {
+      "add_main": {
+        "enable": true,
+        "period": 240,
+        "loop": true
+      },
+      "add_sub": {
+        "enable": true,
+        "period": 240
+      },
+      "copyArchive": {
+        "enable": true,
+        "period": 2400,
+        "sync": true
+      },
+      "datasetManager": {
+        "enable": true,
+        "period": 2400,
+        "sync": true
+      },
+      "process_workflow_files_daemon": {
+        "enable": true,
+        "period": 60
+      },
+      "proxyCache": {
+        "enable": true,
+        "module": "panda_activeusers_query",
+        "period": 600
+      },
+      "pilot_streaming": {
+        "enable": true,
+        "module": "pilotStreaming",
+        "period": 300
+      },
       "configurator": {
         "enable": true,
         "module": "configurator",
         "period": 200,
         "sync": true
       },
-      "pilot_streaming": {
+      "network_configurator": {
         "enable": true,
-        "module": "pilotStreaming",
+        "module": "configurator",
+        "arguments": ["--network"],
+        "period": 400,
+        "sync": true
+      },
+      "schedconfig_json": {
+        "enable": true,
+        "module": "configurator",
+        "arguments": ["--json_dump"],
+        "period": 200,
+        "sync": true
+      },
+      "sw_tags": {
+        "enable": true,
+        "module": "configurator",
+        "arguments": ["--sw_tags"],
+        "period": 200,
+        "sync": true
+      },
+      "cache_schedconfig": {
+        "enable": true,
         "period": 300
+      },
+      "cache_pilots": {
+        "enable": true,
+        "period": 3600
       }
     }
   }


### PR DESCRIPTION
## Summary

- **panda-server** (`panda_server_config.atlas_testbed.json`): previously only `configurator` and `pilot_streaming` were in the daemon `config` block. Added the full set of daemons matching production (`panda_server.cfg.rpmnew.template`):
  - `add_main` / `add_sub` — process job output files after completion
  - `copyArchive` — housekeeping: archives old jobs and kills jobs stuck in `defined` state beyond timeout (root cause of 50 jobs stuck in `defined`)
  - `datasetManager` — dataset lifecycle management, triggers closer/activator
  - `process_workflow_files_daemon` — CWL/Snakemake workflow file processing
  - `proxyCache` (`panda_activeusers_query`) — proxy/token cache refresh
  - `network_configurator`, `schedconfig_json`, `sw_tags` — additional configurator variants
  - `cache_schedconfig`, `cache_pilots` — schedconfig/pilot JSON caches

- **panda-jedi** (`panda_jedi_config.atlas_testbed.json`): two gaps vs production node (`aipanda089`):
  - `taskrefine`: added missing `procConfig: ":managed|test|ptest|rc_test2:1;:user:1"`
  - `jobbroker`: added missing `NW_ACTIVE: "True"` to enable network-aware brokerage

## Root cause

After the CephFS PVC migration (PR #187), pods restarted. In-flight `Setupper` threads were killed, leaving ~50 jobs in `defined` state. Without `copyArchive` running, these jobs were never reassigned/killed for JEDI to regenerate. Without `add_main`, output files from completing jobs were never processed.

## Test plan

- [ ] Redeploy panda-server on atlas testbed (`helm upgrade`)
- [ ] Verify daemon master logs show new daemons being scheduled (`/var/log/panda/panda_daemon_stdout.log`)
- [ ] After first `copyArchive` run (~40 min), verify stuck `defined` jobs are cleaned up
- [ ] Verify `panda-add_main.log` shows output file processing activity