### PR TITLE
fix(bigmon): support x509_proxy Rucio auth, mirroring panda-server setup

### DIFF
--- a/helm/bigmon/charts/main/sandbox/rucio.cfg.template
+++ b/helm/bigmon/charts/main/sandbox/rucio.cfg.template
@@ -6,10 +6,10 @@ logformat = %%(asctime)s\t%%(process)d\t%%(levelname)s\t%%(message)s
 [client]
 rucio_host = https://${RUCIO_SERVER_HOST}
 auth_host = https://${RUCIO_AUTH_HOST}
-auth_type = userpass
+auth_type = ${RUCIO_AUTH_TYPE}
 username = ${RUCIO_USERNAME}
 password = ${RUCIO_PASSWORD}
-ca_cert = /etc/grid-security/certificates/
+ca_cert = ${RUCIO_CA_CERT}
 account = ${RUCIO_ACCOUNT}
 request_retries = 3
 protocol_stat_retries = 6

--- a/secrets/templates/bigmon.yaml
+++ b/secrets/templates/bigmon.yaml
@@ -80,9 +80,20 @@ stringData:
   RUCIO_SERVER_HOST: "{{ .Values.rucio.rucioHost }}"
   RUCIO_AUTH_HOST: "{{ .Values.rucio.authHost }}"
   RUCIO_ACCOUNT: "{{ .Values.rucio.account }}"
+  RUCIO_CONFIG: "/opt/bigmon/etc/rucio.cfg"
+  {{- if eq (.Values.rucio.authType | default "userpass") "x509_proxy" }}
+  RUCIO_AUTH_TYPE: "x509_proxy"
+  X509_USER_PROXY: "/opt/bigmon/etc/cert/{{ base .Values.rucio.clientX509Proxy }}"
+  RUCIO_CA_CERT: "{{ .Values.rucio.caCert | default "/etc/grid-security/certificates/" }}"
+  RUCIO_USERNAME: ""
+  RUCIO_PASSWORD: ""
+  {{- else }}
+  RUCIO_AUTH_TYPE: "userpass"
+  X509_USER_PROXY: ""
+  RUCIO_CA_CERT: "/etc/grid-security/certificates/"
   RUCIO_USERNAME: "{{ .Values.rucio.username }}"
   RUCIO_PASSWORD: "{{ .Values.rucio.password }}"
-  RUCIO_CONFIG: "/opt/bigmon/etc/rucio.cfg"
+  {{- end }}
 
   # CRIC
   {{- if .Values.cric.real }}
@@ -114,6 +125,10 @@ metadata:
 type: Opaque
 data:
   {{- range $path, $_ := .Files.Glob "files/bigmon_certs/**.pem" }}
+  {{ base $path }}: |-
+    {{ $.Files.Get $path | b64enc }}
+  {{- end }}
+  {{- range $path, $_ := .Files.Glob "files/panda_certs/**.proxy" }}
   {{ base $path }}: |-
     {{ $.Files.Get $path | b64enc }}
   {{- end }}


### PR DESCRIPTION
## Summary

- BigMon's `rucio.cfg.template` hardcoded `auth_type = userpass` and a static `ca_cert`, ignoring `rucio.authType` from values
- The `bigmon-envs` secret had no conditional Rucio auth logic and always fell back to `rucio.username`/`rucio.password` defaults (`iddsv1`/`FIXME`)
- BigMon now supports the same `rucio.authType` values as panda-server/jedi

## Changes

**`secrets/templates/bigmon.yaml`**
- Rucio env block now mirrors `secrets/templates/panda.yaml`: when `rucio.authType=x509_proxy`, sets `RUCIO_AUTH_TYPE=x509_proxy`, derives `X509_USER_PROXY=/opt/bigmon/etc/cert/<proxy-filename>`, and clears username/password
- `.proxy` files from `secrets/files/panda_certs/` are included in the `bigmon-certs` secret so BigMon reuses the same proxy as panda-server (single file to maintain)

**`helm/bigmon/charts/main/sandbox/rucio.cfg.template`**
- `auth_type` and `ca_cert` are now dynamic via `${RUCIO_AUTH_TYPE}` and `${RUCIO_CA_CERT}`

## How to enable for atlas_testbed

No additional values changes needed — `rucio.authType: "x509_proxy"` and `rucio.clientX509Proxy` are already set in `values-secret.yaml`. After deploying the updated secrets chart, the bigmon-certs secret will include the proxy and BigMon will authenticate to Rucio with x509.