### PR TITLE
fix(atlas-testbed): auto-evict pods from NotReady nodes after 30s

### DIFF
--- a/helm/bigmon/values/values-atlas_testbed.yaml
+++ b/helm/bigmon/values/values-atlas_testbed.yaml
@@ -4,6 +4,15 @@
 #
 
 main:
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
   persistentvolume:
     create: true
     size: 50Gi

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -3,6 +3,15 @@
 
 harvester:
   experiment: atlas
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
   ingress:
     enabled: true
     annotations:

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -4,6 +4,15 @@
 
 server:
   configFile: panda_server_config.atlas_testbed.json
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
   resources:
     requests:
       cpu: "2"
@@ -37,6 +46,15 @@ server:
 
 jedi:
   configFile: panda_jedi_config.atlas_testbed.json
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
## Problem

Nodes in the CERN testbed cluster go NotReady periodically. When this happens, StatefulSet pods (`panda-server-0`, `panda-jedi-0`, `panda-bigmon-main-0`, `panda-harvester-0`) get stuck in `Terminating` indefinitely, requiring manual `kubectl delete pod --force --grace-period=0` each time.

Kubernetes intentionally does not auto-evict StatefulSet pods from NotReady nodes (to protect stateful data), but the default `tolerationSeconds` for the built-in `not-ready` taint is 300 seconds for Deployments and infinite for StatefulSets — resulting in permanent stuck pods until manually intervened.

## Fix

Add `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` tolerations with `tolerationSeconds: 30` to all atlas_testbed values files (server, jedi, bigmon, harvester).

After 30 seconds on a NotReady node, Kubernetes evicts and reschedules the pod automatically on a healthy node — no manual intervention needed.

## Files changed

- `helm/panda/values/values-atlas_testbed.yaml` — server + jedi
- `helm/bigmon/values/values-atlas_testbed.yaml` — bigmon main
- `helm/harvester/values/values-atlas_testbed.yaml` — harvester