### PR TITLE
feat(panda): add node-recovery CronJob to auto-force-delete stuck Terminating pods

### DIFF
--- a/helm/panda/templates/node-recovery-cronjob.yaml
+++ b/helm/panda/templates/node-recovery-cronjob.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.nodeRecovery.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-node-recovery
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-node-recovery
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-node-recovery
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-node-recovery
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-node-recovery
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-node-recovery
+  namespace: {{ .Release.Namespace }}
+spec:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 50
+      template:
+        spec:
+          serviceAccountName: {{ .Release.Name }}-node-recovery
+          restartPolicy: Never
+          containers:
+            - name: node-recovery
+              image: {{ .Values.nodeRecovery.image | default "bitnami/kubectl:latest" }}
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  NOT_READY_NODES=$(kubectl get nodes --no-headers | awk '$2 == "NotReady" {print $1}')
+                  if [ -z "$NOT_READY_NODES" ]; then
+                    echo "All nodes Ready."
+                    exit 0
+                  fi
+                  for NODE in $NOT_READY_NODES; do
+                    echo "Node $NODE is NotReady — checking for stuck Terminating pods..."
+                    kubectl get pods --all-namespaces \
+                      --field-selector="spec.nodeName=${NODE}" \
+                      -o json | \
+                    jq -r '.items[] | select(.metadata.deletionTimestamp != null) | [.metadata.namespace, .metadata.name] | @tsv' | \
+                    while IFS=$'\t' read -r NS NAME; do
+                      echo "Force-deleting $NS/$NAME on NotReady node $NODE"
+                      kubectl delete pod -n "$NS" "$NAME" --force --grace-period=0
+                    done
+                  done
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+{{- end }}

--- a/helm/panda/values.yaml
+++ b/helm/panda/values.yaml
@@ -108,3 +108,8 @@ postgres:
     requests:
       cpu: 4000m
       memory: 16Gi
+
+
+nodeRecovery:
+  enabled: false
+  image: "bitnami/kubectl:latest"

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -68,6 +68,9 @@ jedi:
     selector: false
     size: 50Gi
 
+nodeRecovery:
+  enabled: true
+
 postgres:
     enabled: false
 


### PR DESCRIPTION
## Problem

When a cluster node goes NotReady, StatefulSet pods on that node get stuck in `Terminating` indefinitely. The kubelet on the failed node cannot acknowledge the deletion, so the StatefulSet controller won't schedule a replacement.

PR #191 added `tolerationSeconds: 30` so Kubernetes automatically initiates the eviction after 30 seconds — but the pod still gets stuck in `Terminating` and requires a manual `kubectl delete pod --force --grace-period=0`.

## Solution

A CronJob that runs every 60 seconds, watches all namespaces, and force-deletes any pod that:
1. Is on a NotReady node, **and**
2. Has a `deletionTimestamp` set (i.e. is in `Terminating` state)

This covers **all components** — panda-server, panda-jedi, panda-bigmon, panda-harvester, and any others — not just panda/jedi.

## RBAC

Minimal ClusterRole: `get`/`list` on nodes, `get`/`list`/`delete` on pods.

## Configuration

Disabled by default (`nodeRecovery.enabled: false`). Enabled for atlas_testbed via `values-atlas_testbed.yaml`.

## Together with PR #191

- **#191 (tolerations)**: pod goes `Running` → `Terminating` automatically after 30s on NotReady node
- **This PR (CronJob)**: pod goes `Terminating` → gone within 60s, replacement scheduled immediately

Combined effect: full automated recovery within ~90 seconds of a node going NotReady, zero manual intervention.