### PR TITLE
fix(harvester): migrate mariadb from hostPath on node-4 to subPath of wdirs CephFS PVC

### DIFF
--- a/helm/harvester/charts/mariadb/templates/statefulset.yaml
+++ b/helm/harvester/charts/mariadb/templates/statefulset.yaml
@@ -89,8 +89,14 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: {{ include "mariadb.fullname" . }}-data
+              {{- if .Values.persistentvolume.subPath }}
+              subPath: {{ .Values.persistentvolume.subPath }}
+              {{- end }}
             - mountPath: /bitnami/mariadb
               name: {{ include "mariadb.fullname" . }}-data
+              {{- if .Values.persistentvolume.subPath }}
+              subPath: {{ .Values.persistentvolume.subPath }}
+              {{- end }}
             - mountPath: /docker-entrypoint-initdb.d
               name: {{ include "mariadb.fullname" . }}-initdb
             - mountPath: /opt/bitnami/mariadb/conf/my_custom.cnf
@@ -110,7 +116,7 @@ spec:
       volumes:
         - name: {{ include "mariadb.fullname" . }}-data
           persistentVolumeClaim:
-            claimName: {{ include "mariadb.fullname" . }}
+            claimName: {{ .Values.persistentvolume.existingClaim | default (include "mariadb.fullname" .) }}
         - name: {{ include "mariadb.fullname" . }}-initdb
           secret:
             secretName: {{ .Values.global.secret }}-harvester-initdb

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -50,6 +50,11 @@ harvester:
       memory: 8Gi
 
 mariadb:
+  persistentvolume:
+    create: false
+    selector: false
+    existingClaim: panda-harvester-wdirs
+    subPath: mariadb-data
   resources:
     requests:
       cpu: "500m"


### PR DESCRIPTION
## Problem

The MariaDB PV backing Harvester's database was a `hostPath` volume pinned to `testbed-zrvqf5cage3t-node-4` via `nodeAffinity`. Every time node-4 went NotReady (hypervisor instability), MariaDB could not be rescheduled anywhere else, taking Harvester's DB down and stopping all pilot submission to CERN — leaving submitted tasks stuck in `activated`.

## Fix

Reuse the existing `panda-harvester-wdirs` CephFS PVC (50Gi RWX, `manila-meyrin-cephfs`) with a dedicated `mariadb-data/` subPath for the MariaDB data directory. MariaDB can now reschedule on any node.

A new `existingClaim` + `subPath` option is added to the mariadb chart so the volume binding can be configured from values without creating a new PVC (the project CephFS share quota is already at the limit).

## Migration steps (atlas_testbed)

1. `mysqldump --all-databases` taken before any changes
2. Old hostPath PVC/PV deleted
3. This PR merged + ArgoCD synced → MariaDB comes up on wdirs subPath (empty DB)
4. Dump restored into new pod