### PR TITLE
fix(mariadb): skip PVC creation when existingClaim is set

### DIFF
--- a/helm/harvester/charts/mariadb/templates/statefulset.yaml
+++ b/helm/harvester/charts/mariadb/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistentvolume.create }}
+{{- if and .Values.persistentvolume.create (not .Values.persistentvolume.existingClaim) }}
 # pv
 kind: PersistentVolume
 apiVersion: v1
@@ -17,6 +17,7 @@ spec:
     path: {{ .Values.persistentvolume.path }}
 ---
 {{- end }}
+{{- if not .Values.persistentvolume.existingClaim }}
 # pv claim
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -37,6 +38,7 @@ spec:
       {{- include "mariadb.selectorLabels" . | nindent 6 }}
   {{- end }}
 ---
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Follow-up to #193. The mariadb chart was still creating a `panda-harvester-mariadb` PVC (with `storageClass: manual`) even when `existingClaim` was configured, causing a dangling Pending PVC managed by ArgoCD.

Guard both the PV and PVC creation blocks behind `not .Values.persistentvolume.existingClaim` so that when an existing claim is used, no spurious resources are created.