### PR TITLE
fix(server): remove conflicting ssl.conf and install IGTF CA certs on startup

### DIFF
--- a/helm/panda/charts/server/templates/statefulset.yaml
+++ b/helm/panda/charts/server/templates/statefulset.yaml
@@ -94,6 +94,8 @@ spec:
                   ln -s /opt/panda/sandbox/panda_server-httpd.conf /opt/panda/etc/panda/panda_server-httpd.conf;
                fi;
               /opt/panda/bin/python /data/panda/process_template.py;
+              rm -f /etc/httpd/conf.d/ssl.conf;
+              /opt/panda/bin/panda_common-install_igtf_ca;
               /data/panda/run-panda-services;
               sleep infinity & wait
           {{- end }}


### PR DESCRIPTION
## Problem

Every time `panda-server-0` is rescheduled on a fresh pod (e.g. after a node goes NotReady), two cascading failures prevent Apache from starting:

1. **`/etc/httpd/conf.d/ssl.conf`** — installed by the OS `httpd` RPM, references `/etc/pki/tls/certs/localhost.crt` which doesn't exist in the container. Apache crashes immediately on startup.

2. **Empty `/etc/grid-security/certificates/`** — `panda_common-install_igtf_ca` runs in `init-panda` at pod start but can fail if the network isn't ready yet (HTTP timeout), leaving the CA cert directory empty. Apache then fails with `AH01896: Unable to determine list of acceptable CA certificates`.

Both failures require manual intervention inside the running pod to fix.

## Fix

Add both fixes to the container startup `command` block, before `run-panda-services` is called:

```bash
rm -f /etc/httpd/conf.d/ssl.conf
/opt/panda/bin/panda_common-install_igtf_ca
```

This runs in the main container's writable layer, so changes take effect immediately. The pod is now self-healing on every restart.

## Notes

- The `ssl.conf` fix is also in the upstream Docker image (PanDAWMS/panda-server#695) and will become redundant once a new image is released.
- The IGTF cert install here runs after the network is confirmed available (post-`process_template.py`), avoiding the timing issue that caused it to fail at pod start.