### PR TITLE
fix(atlas-testbed): reduce panda-server and jedi resource limits to fit m2.large nodes

### DIFF
--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -18,8 +18,8 @@ server:
       cpu: "2"
       memory: 4Gi
     limits:
-      cpu: "6"
-      memory: 8Gi
+      cpu: "4"
+      memory: 6Gi
   persistentvolume:
     create: false
     class: manila-meyrin-cephfs
@@ -60,8 +60,8 @@ jedi:
       cpu: "2"
       memory: 4Gi
     limits:
-      cpu: "6"
-      memory: 8Gi
+      cpu: "4"
+      memory: 6Gi
   persistentvolume:
     create: false
     class: manila-meyrin-cephfs


### PR DESCRIPTION
## Problem

`panda-server` and `panda-jedi` had memory limits of 8 Gi on m2.large nodes that only have 7.5 GB RAM total. System pods (CephFS CSI, Calico, kubelet, etc.) consume ~1.5-2 GB, leaving ~5-6 GB for application pods.

With an 8 Gi limit, panda-server can consume the entire node's available memory before Kubernetes can evict it, causing OOM at the **node** level instead of the pod level — killing the node entirely rather than just restarting the pod.

This caused node-0, node-3, and node-4 to go NotReady in sequence today as panda-server kept rescheduling and OOM-killing each m2.large node it landed on.

## Fix

Reduce limits to `6 Gi` RAM / `4` CPU for both panda-server and panda-jedi, leaving sufficient headroom for system pods and ensuring OOM eviction happens at the pod level.

Root cause identified by Diana Gaponcic (CERN Cloud team).