### PR TITLE
fix(atlas-testbed): add podAntiAffinity to spread server, jedi, harvester across nodes

### DIFF
--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -29,6 +29,21 @@ harvester:
       - hosts:
           - domain: cern.ch
             hostOverride: bigpanda-tb.cern.ch
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: server
+            topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: jedi
+            topologyKey: kubernetes.io/hostname
   persistentvolume:
     create: false
     class: manila-meyrin-cephfs

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -13,6 +13,21 @@ server:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 30
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: jedi
+            topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: harvester
+            topologyKey: kubernetes.io/hostname
   resources:
     requests:
       cpu: "2"
@@ -55,6 +70,21 @@ jedi:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 30
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: server
+            topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: harvester
+            topologyKey: kubernetes.io/hostname
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
## Summary

- Adds soft `podAntiAffinity` rules to `panda-server`, `panda-jedi`, and `panda-harvester` for the atlas testbed
- Each of the three heavy pods prefers not to share a node with either of the other two
- Uses `preferredDuringSchedulingIgnoredDuringExecution` (weight 100) — scheduling is never blocked if the cluster is constrained

## Motivation

After the m2.large resize, multiple memory-heavy pods were landing on the same node, causing OOM kills. With 6 worker nodes available this is unnecessary — the scheduler just needs a nudge.

## Test plan

- [ ] ArgoCD syncs `panda` and `panda-harvester` apps after merge
- [ ] `kubectl get pods -o wide` shows server, jedi, harvester on separate nodes after next pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)