### PR TITLE
fix(atlas-testbed): add podAntiAffinity to keep harvester off idds node

### DIFF
--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -44,6 +44,12 @@ harvester:
               matchLabels:
                 app.kubernetes.io/name: jedi
             topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: rest
+            topologyKey: kubernetes.io/hostname
   persistentvolume:
     create: false
     class: manila-meyrin-cephfs


### PR DESCRIPTION
## Summary

- Adds a soft `podAntiAffinity` rule to `panda-harvester` to avoid co-scheduling with `panda-idds-rest` (both are memory-heavy and currently share node-5)
- Uses `preferredDuringSchedulingIgnoredDuringExecution` (weight 100) — soft rule, won't block scheduling if no alternative node is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)