### PR TITLE
fix(atlas-testbed): raise panda-server memory limit to 10Gi; bump bigmon to v0.7.11

### DIFF
--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -12,7 +12,7 @@ main:
   enabled: true
 
   image:
-    tag: "v0.7.10"
+    tag: "v0.7.11"
 
   autoStart: true
 

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -55,7 +55,7 @@ server:
       memory: 4Gi
     limits:
       cpu: "4"
-      memory: 6Gi
+      memory: 10Gi
   persistentvolume:
     create: false
     class: manila-meyrin-cephfs


### PR DESCRIPTION
## Summary

- Raise `panda-server` memory limit `6Gi → 10Gi`: was OOMKilled 50+ times on the m4.large node (14.6 GB RAM); soft node affinity keeps it on m4.large where 10Gi is safe
- Bump bigmon image `v0.7.10 → v0.7.11`: includes fix for `UnboundLocalError` in `get_rucio_username_by_produserid` for OIDC jobs ([panda-bigmon-core#629](https://github.com/PanDAWMS/panda-bigmon-core/pull/629))

## Test plan

- [ ] ArgoCD syncs both `panda` and `panda-bigmon` apps
- [ ] panda-server-0 stops OOMKilling
- [ ] bigmon job pages load correctly for OIDC jobs without "Oops" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)