### PR TITLE
fix(atlas-testbed): reduce httpd workers to prevent panda-server OOM

### DIFF
--- a/helm/panda/charts/server/templates/configmap.yaml
+++ b/helm/panda/charts/server/templates/configmap.yaml
@@ -35,6 +35,9 @@ data:
   {{- if .Values.noRoot }}
   PANDA_NO_ROOT: "1"
   {{- end }}
+  {{- range $key, $value := .Values.extraEnv }}
+  {{ $key }}: "{{ $value }}"
+  {{- end }}
 
 ---
 # sandbox

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -49,6 +49,11 @@ server:
               matchLabels:
                 app.kubernetes.io/name: rest
             topologyKey: kubernetes.io/hostname
+  extraEnv:
+    PANDA_SERVER_CONF_MIN_WORKERS: "4"
+    PANDA_SERVER_CONF_MAX_WORKERS: "100"
+    PANDA_SERVER_CONF_NUM_WSGI: "8"
+    PANDA_SERVER_CONF_NUM_WSGI_THREAD: "2"
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
## Summary

- Add `extraEnv` support to the server chart configmap (allows passing arbitrary env vars to the server container via values)
- Set testbed-appropriate Apache/mod_wsgi worker counts to prevent OOMKill

## Root cause

The panda-server image defaults are tuned for production scale:
- `PANDA_SERVER_CONF_MIN_WORKERS=32` → starts with 32 httpd server processes
- `PANDA_SERVER_CONF_MAX_WORKERS=512` → up to 20 server processes × 25 threads
- `PANDA_SERVER_CONF_NUM_WSGI=32` → 32 mod_wsgi daemon processes

Combined, this spawns ~87 processes consuming ~12 GB RSS — exceeding the 10 Gi container limit and causing repeated OOMKill (exit code 137).

## Fix

| Variable | Default | Testbed override |
|---|---|---|
| `PANDA_SERVER_CONF_MIN_WORKERS` | 32 | **4** |
| `PANDA_SERVER_CONF_MAX_WORKERS` | 512 | **100** (4 proc × 25 threads) |
| `PANDA_SERVER_CONF_NUM_WSGI` | 32 | **8** |
| `PANDA_SERVER_CONF_NUM_WSGI_THREAD` | 1 | **2** |

Expected footprint: ~12 processes × ~180 MB ≈ **~2.2 GB** (down from ~12 GB).

## Test plan
- [ ] ArgoCD syncs and panda-server-0 restarts cleanly
- [ ] `kubectl exec panda-server-0 -- ps aux | grep httpd | wc -l` shows ~12 processes (not ~87)
- [ ] No OOMKill after restart (`kubectl get pod panda-server-0` shows 0 new restarts)