### PR TITLE
fix(atlas-testbed): grant production role to /atlas/Role=production VOMS cert holders

### DIFF
--- a/helm/panda/charts/server/panda_server_config.atlas_testbed.json
+++ b/helm/panda/charts/server/panda_server_config.atlas_testbed.json
@@ -29,7 +29,7 @@
     "dbbridgeverbose": "False",
     "dump_sql": "False",
     "useJEDI": "True",
-    "production_dns": "pandasv,atlpilo,atlact,Robot Pilot,Robot Harvester",
+    "production_dns": "pandasv,atlpilo,atlact,Robot Pilot,Robot Harvester,/atlas/Role=production",
     "pilot_owners": "/atlas/usatlas/Role=production,/atlas/Role=pilot,ATLAS Pilot1,ATLAS Pilot2,peter love,Andrej Filipcic,usathpc",
     "adder_plugins": "local:dataservice.AdderDummyPlugin:AdderDummyPlugin",
     "setupper_plugins": "local:dataservice.SetupperDummyPlugin:SetupperDummyPlugin",


### PR DESCRIPTION
## Summary

Add `/atlas/Role=production` to `production_dns` in the testbed panda-server config so that users with an ATLAS production certificate can use the production API endpoints.

## Root cause

`production_dns` only listed internal robot accounts (`pandasv`, `atlpilo`, `atlact`, etc.). Users holding a valid `/atlas/Role=production` VOMS certificate were denied production-level access on the testbed, even though `pilot_owners` already correctly included VOMS role patterns.

## Fix

```diff
- "production_dns": "pandasv,atlpilo,atlact,Robot Pilot,Robot Harvester",
+ "production_dns": "pandasv,atlpilo,atlact,Robot Pilot,Robot Harvester,/atlas/Role=production",
```

## Test plan
- [ ] ArgoCD syncs and restarts panda-server-0
- [ ] User with `/atlas/Role=production` certificate can successfully use the production API on the testbed