### PR TITLE
feat(doma): add DOMA harvester configmap, fix PVC sizes, add ArgoCD Application manifests

### DIFF
--- a/argocd-apps/doma/bigmon.yaml
+++ b/argocd-apps/doma/bigmon.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda-bigmon
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/bigmon
+    helm:
+      valueFiles:
+        - values.yaml
+        - values/values-cern.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd-apps/doma/harvester.yaml
+++ b/argocd-apps/doma/harvester.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda-harvester
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/harvester
+    helm:
+      valueFiles:
+        - values.yaml
+        - values/values-cern.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd-apps/doma/idds.yaml
+++ b/argocd-apps/doma/idds.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda-idds
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/idds
+    helm:
+      valueFiles:
+        - values.yaml
+        - values/values-doma-k8s.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd-apps/doma/msgsvc.yaml
+++ b/argocd-apps/doma/msgsvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda-msgsvc
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/msgsvc
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd-apps/doma/panda.yaml
+++ b/argocd-apps/doma/panda.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/panda
+    helm:
+      valueFiles:
+        - values.yaml
+        - values/values-cern.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -5,7 +5,9 @@
 
 main:
   persistentvolume:
-    create: true
+    create: false
+    selector: false
+    size: 50Gi
 
   ingress:
     enabled: true

--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -8,15 +8,15 @@ harvester:
   persistentvolume:
     create: false
     selector: false
-    size: 5Gi
+    size: 50Gi
   persistentvolumewdir:
     create: false
     selector: false
-    size: 5Gi
+    size: 50Gi
   persistentvolumecondor:
     create: false
     selector: false
-    size: 5Gi
+    size: 50Gi
 
   resources:
     requests:

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -19,7 +19,15 @@ server:
         hosts:
           - domain: cern.ch
             hostOverride: pandaserver-doma.cern.ch
+  persistentvolume:
+    create: false
+    selector: false
+    size: 50Gi
   configFile: "panda_server_config.cern.json"
 
 jedi:
+  persistentvolume:
+    create: false
+    selector: false
+    size: 50Gi
   configFile: "panda_jedi_config.cern.json"


### PR DESCRIPTION
## Summary

- Add `configmap/doma.panda_harvester_configmap.json` with DOMA-specific credential managers (IAM tokens for pilot/CE/PanDA auth + x509 ATLAS VOMS proxies via `NoVomsCredManager`)
- Fix PVC sizes across all DOMA values files to match actual static PVs on the DOMA cluster (50Gi for server, jedi, bigmon, harvester, condor-logs; 5Gi for mariadb)
- Add `argocd-apps/doma/` with ArgoCD Application manifests for all five DOMA apps (panda, harvester, idds, bigmon, msgsvc), mirroring the `argocd-apps/testbed/` structure

## Details

**Harvester configmap** (`configmap/doma.panda_harvester_configmap.json`):
Selected automatically when `experiment: doma` is set in `values-cern.yaml`. Configures three credential managers:
- `IamTokenCredManager` — IAM tokens for pilot auth, CE submission (prod + pilot), and PanDA server auth
- `TokenKeyCredManager` — PanDA token key (`client_name: Rubin.production`)
- `NoVomsCredManager` — ATLAS VOMS proxies (`/atlas/Role=production` and `/atlas/Role=pilot`) from robot cert

**PVC sizes**: All DOMA values files previously had the chart default of 5Gi; updated to reflect actual pre-existing static PVs (50Gi).

**ArgoCD Applications**: Each manifest uses `destination.server: https://kubernetes.default.svc` (deploys to the cluster ArgoCD is installed in) and references the appropriate `values-cern.yaml` or `values-doma-k8s.yaml` overlay. Once ArgoCD is installed on the DOMA cluster, applying these manifests will bring the full stack under GitOps management.

## Test plan

- [ ] `helm template helm/harvester -f helm/harvester/values/values-cern.yaml` renders configmap with DOMA credential manager config
- [ ] ArgoCD installed on DOMA cluster at `argocd-doma.cern.ch`
- [ ] `kubectl apply -f argocd-apps/doma/` syncs all five apps successfully