### PR TITLE
feat(argocd): add ArgoCD installation manifests for testbed and DOMA clusters

### DIFF
--- a/argocd-install/doma/argocd-cmd-params-cm.yaml
+++ b/argocd-install/doma/argocd-cmd-params-cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cmd-params-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  server.insecure: "true"

--- a/argocd-install/doma/ingress.yaml
+++ b/argocd-install/doma/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - argocd-doma.cern.ch
+      secretName: argocd-tls
+  rules:
+    - host: argocd-doma.cern.ch
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 80

--- a/argocd-install/testbed/argocd-cmd-params-cm.yaml
+++ b/argocd-install/testbed/argocd-cmd-params-cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cmd-params-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  server.insecure: "true"

--- a/argocd-install/testbed/ingress.yaml
+++ b/argocd-install/testbed/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - argocd-tb.cern.ch
+      secretName: argocd-tls
+  rules:
+    - host: argocd-tb.cern.ch
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary

- Add `argocd-install/testbed/` and `argocd-install/doma/` directories
- Each contains `ingress.yaml` (cluster-specific hostname, `argocd-tls` secret) and `argocd-cmd-params-cm.yaml` (`server.insecure: true`)
- These manifests are applied once manually when bootstrapping ArgoCD on a new cluster — they cannot be managed by ArgoCD itself (bootstrap chicken-and-egg)

## Apply instructions

```bash
# Create namespace and install ArgoCD
kubectl create namespace argocd
kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.6/manifests/install.yaml

# Apply insecure-mode configmap and restart
kubectl apply -f argocd-install/<cluster>/argocd-cmd-params-cm.yaml
kubectl rollout restart deployment argocd-server -n argocd

# Create TLS secret from CERN host certificate, then apply ingress
kubectl create secret tls argocd-tls -n argocd --cert=argocd-<cluster>.cern.ch.crt --key=argocd-<cluster>.cern.ch.key
kubectl apply -f argocd-install/<cluster>/ingress.yaml
```