### PR TITLE
fix(doma): add resource limits for panda, postgres, and msgsvc

### DIFF
--- a/argocd-apps/doma/msgsvc.yaml
+++ b/argocd-apps/doma/msgsvc.yaml
@@ -12,6 +12,7 @@ spec:
     helm:
       valueFiles:
         - values.yaml
+        - values/values-cern.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/helm/msgsvc/values/values-cern.yaml
+++ b/helm/msgsvc/values/values-cern.yaml
@@ -1,0 +1,8 @@
+activemq:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -24,6 +24,13 @@ server:
     selector: false
     size: 50Gi
   configFile: "panda_server_config.cern.json"
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "4"
+      memory: 8Gi
 
 jedi:
   persistentvolume:
@@ -31,3 +38,19 @@ jedi:
     selector: false
     size: 50Gi
   configFile: "panda_jedi_config.cern.json"
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "4"
+      memory: 8Gi
+
+postgres:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi


### PR DESCRIPTION
## Summary

- Add resource overrides in `helm/panda/values/values-cern.yaml`: server/jedi 2Gi request / 8Gi limit, postgres 512Mi / 2Gi
- Add `helm/msgsvc/values/values-cern.yaml`: activemq 512Mi / 2Gi
- Wire `values/values-cern.yaml` into `argocd-apps/doma/msgsvc.yaml`

The upstream chart defaults (16Gi requests) are tuned for production and don't fit on DOMA nodes (~14Gi RAM). The old local doma-k8s charts had no resource limits, so the pods ran unrestricted. This PR adds DOMA-appropriate limits so pods can schedule.