### PR TITLE
fix(doma): disable postgres subcharts — DOMA uses external DBOD host

### DIFF
--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -29,7 +29,7 @@ rest:
             hostOverride: panda-idds-doma.cern.ch
 
 postgres:
-  enabled: true
+  enabled: false
 
   resources:
     limits:

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -47,10 +47,4 @@ jedi:
       memory: 8Gi
 
 postgres:
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: "2"
-      memory: 2Gi
+  enabled: false


### PR DESCRIPTION
## Summary

- Set `postgres.enabled: false` in `helm/panda/values/values-cern.yaml`
- Set `postgres.enabled: false` in `helm/idds/values/values-doma-k8s.yaml`

DOMA uses an external DBOD host (`dbod-panda-doma.cern.ch`) for all databases, not in-cluster postgres pods. With `prune: true` in the ArgoCD Applications, merging this will cause ArgoCD to delete the `panda-postgres` and `panda-idds-postgres` deployments and their PVCs automatically.