### PR TITLE
feat(doma): add IAM ArgoCD Application and DOMA values

### DIFF
--- a/argocd-apps/doma/iam.yaml
+++ b/argocd-apps/doma/iam.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda-iam
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/iam
+    helm:
+      valueFiles:
+        - values.yaml
+        - values/values-doma.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/helm/iam/values/values-doma.yaml
+++ b/helm/iam/values/values-doma.yaml
@@ -1,0 +1,23 @@
+main:
+  ingress:
+    enabled: true
+    hosts:
+      - domain: cern.ch
+        hostOverride: panda-iam-doma.cern.ch
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: panda-secrets-iam-tls-certs
+        hosts:
+          - domain: cern.ch
+            hostOverride: panda-iam-doma.cern.ch
+
+  persistentvolume:
+    create: true
+    class: manual
+    path: "/mnt/iam-logs"
+    size: 5Gi
+
+mariadb:
+  enabled: false


### PR DESCRIPTION
## Summary

- Add `argocd-apps/doma/iam.yaml` — ArgoCD Application to deploy IAM at `panda-iam-doma.cern.ch`
- Add `helm/iam/values/values-doma.yaml` — DOMA-specific values:
  - Ingress hostname: `panda-iam-doma.cern.ch`
  - TLS secret: `panda-secrets-iam-tls-certs` (provided by the secrets Helm chart from `secrets/files/iam_certs/`)
  - `mariadb.enabled: false` — uses external DBOD host (`dbod-panda-doma.cern.ch`)
  - `persistentvolume.create: true` — chart creates PV/PVC with hostPath `/mnt/iam-logs`, 5Gi

## Apply

After merging, apply the Application manifest to the DOMA cluster:
```bash
export KUBECONFIG=~/cernbox/doma-k8s/config
kubectl apply -f argocd-apps/doma/iam.yaml
```