### PR TITLE
fix(doma): stop ArgoCD sync loops and manage harvester PVs via Helm

### DIFF
--- a/argocd-apps/doma/harvester.yaml
+++ b/argocd-apps/doma/harvester.yaml
@@ -23,3 +23,10 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: panda-harvester
+      jsonPointers:
+        - /spec/volumeClaimTemplates

--- a/argocd-apps/doma/panda.yaml
+++ b/argocd-apps/doma/panda.yaml
@@ -30,3 +30,13 @@ spec:
       name: panda-external-sandbox
       jsonPointers:
         - /binaryData
+    - group: apps
+      kind: StatefulSet
+      name: panda-server
+      jsonPointers:
+        - /spec/volumeClaimTemplates
+    - group: apps
+      kind: StatefulSet
+      name: panda-jedi
+      jsonPointers:
+        - /spec/volumeClaimTemplates

--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -4,19 +4,25 @@
 harvester:
   experiment: doma
 
-  # DOMA uses pre-existing static PVs (storageclass: manual)
+  # DOMA uses static hostPath PVs on node-3
   persistentvolume:
-    create: false
+    create: true
+    class: manual
+    path: "/mnt/harvester-logs"
     selector: false
     size: 50Gi
   persistentvolumewdir:
-    create: false
     selector: false
     size: 50Gi
   persistentvolumecondor:
-    create: false
+    create: true
+    class: manual
+    path: "/mnt/harvester-logs"
     selector: false
-    size: 50Gi
+    size: 5Gi
+
+  nodeSelector:
+    kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3
 
   resources:
     requests:
@@ -28,9 +34,15 @@ harvester:
 
 mariadb:
   persistentvolume:
-    create: false
+    create: true
+    class: manual
+    path: "/mnt/harvester-data"
     selector: false
     size: 5Gi
+
+  nodeSelector:
+    kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3
+
   resources:
     requests:
       cpu: "250m"


### PR DESCRIPTION
## Summary

- **panda app infinite heal loop**: `panda-server` and `panda-jedi` StatefulSets were stuck in a 471-attempt self-heal loop because Kubernetes adds `volumeMode: Filesystem` and `status.phase: Pending` to `volumeClaimTemplates` entries after creation — fields absent from the Helm chart output. Added `ignoreDifferences` for `/spec/volumeClaimTemplates` on both StatefulSets. Since volumeClaimTemplates are immutable this is always safe to ignore.
- **panda-harvester PVs pruned by ArgoCD**: DOMA harvester values had `persistentvolume.create: false` which means PVs are not in the Helm chart output. ArgoCD with `prune: true` deleted the manually pre-created PVs. Switched all three volumes (logs, condor-logs, mariadb) to `create: true` so ArgoCD owns and preserves the PVs. Added correct DOMA hostPaths (`/mnt/harvester-logs`, `/mnt/harvester-data`) and nodeSelector pinning both pods to `node-3` where the hostPath directories exist.
- **panda-harvester ArgoCD app**: added `RespectIgnoreDifferences=true` and equivalent StatefulSet `ignoreDifferences` for consistency.

## Operational steps required after merge

The Terminating PVs (`panda-harvester-condor-logs`, `panda-harvester-wdirs`, `panda-harvester-mariadb`) are stuck waiting for the orphaned `panda-harvester-0` pod to release them. After merge:

```bash
# 1. Delete orphaned pod (releases PVC bindings)
kubectl delete pod panda-harvester-0

# 2. Remove pv-protection finalizers so Terminating PVs complete deletion
kubectl patch pv panda-harvester-condor-logs -p '{"metadata":{"finalizers":null}}'
kubectl patch pv panda-harvester-wdirs -p '{"metadata":{"finalizers":null}}'
kubectl patch pv panda-harvester-mariadb -p '{"metadata":{"finalizers":null}}'

# 3. Delete the Lost PVCs so ArgoCD recreates them against the new PVs
kubectl delete pvc panda-harvester-condor-logs panda-harvester-wdirs panda-harvester-mariadb

# 4. For panda-bigmon: delete pod so the Terminating PVC can complete, then delete old PV
kubectl delete pod panda-bigmon-main-0
kubectl delete pv panda-bigmon-main
```

ArgoCD will then recreate all resources cleanly on the next sync cycle.

## Test plan
- [ ] `kubectl get applications -n argocd` → all 5 apps Synced/Healthy
- [ ] `panda` app no longer shows 471+ auto-heal attempts
- [ ] `panda-harvester` StatefulSet and pods created fresh on node-3
- [ ] `kubectl get pvc | grep harvester` → all PVCs Bound
- [ ] `panda-bigmon` PVC/PV recreated without nodeAffinity/accessMode mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)