### PR TITLE
fix(testbed): stop ArgoCD StatefulSet sync loops via ignoreDifferences

### DIFF
--- a/argocd-apps/testbed/harvester.yaml
+++ b/argocd-apps/testbed/harvester.yaml
@@ -23,3 +23,10 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: panda-harvester
+      jsonPointers:
+        - /spec/volumeClaimTemplates

--- a/argocd-apps/testbed/panda.yaml
+++ b/argocd-apps/testbed/panda.yaml
@@ -30,3 +30,13 @@ spec:
       name: panda-external-sandbox
       jsonPointers:
         - /binaryData
+    - group: apps
+      kind: StatefulSet
+      name: panda-server
+      jsonPointers:
+        - /spec/volumeClaimTemplates
+    - group: apps
+      kind: StatefulSet
+      name: panda-jedi
+      jsonPointers:
+        - /spec/volumeClaimTemplates


### PR DESCRIPTION
## Summary

Same fix as #215 (DOMA), applied to the ATLAS testbed cluster.

Kubernetes enriches `StatefulSet.spec.volumeClaimTemplates` entries with `volumeMode: Filesystem` and `status.phase: Pending` after creation — fields that are absent from the Helm chart output. ArgoCD detects these as a diff and re-applies on every reconciliation cycle (self-heal loop). Since `volumeClaimTemplates` are immutable, ignoring them in the diff comparison is always safe.

- `argocd-apps/testbed/panda.yaml`: ignore `/spec/volumeClaimTemplates` on `panda-server` and `panda-jedi`
- `argocd-apps/testbed/harvester.yaml`: add `RespectIgnoreDifferences=true` + ignore `/spec/volumeClaimTemplates` on `panda-harvester`

## Test plan
- [ ] `kubectl get applications -n argocd` → `panda` and `panda-harvester` move to Synced/Healthy
- [ ] No more continuous self-heal attempts on panda-server/panda-jedi StatefulSets

🤖 Generated with [Claude Code](https://claude.com/claude-code)