### PR TITLE
feat(cvmfs): add CVMFS mount support to server, jedi, harvester, idds, bigmon

### DIFF
--- a/helm/bigmon/charts/main/templates/cvmfs-volumes.yaml
+++ b/helm/bigmon/charts/main/templates/cvmfs-volumes.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.cvmfs.enabled }}
+{{- range .Values.cvmfs.repositories }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "main.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: cvmfs.csi.cern.ch
+    volumeHandle: {{ include "main.fullname" $ }}-cvmfs-{{ .name }}
+    volumeAttributes:
+      repository: {{ .repository }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "main.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  volumeName: {{ include "main.fullname" $ }}-cvmfs-{{ .name }}
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+{{- end }}

--- a/helm/bigmon/charts/main/templates/statefulset.yaml
+++ b/helm/bigmon/charts/main/templates/statefulset.yaml
@@ -100,6 +100,12 @@ spec:
                 mountPath: /data/bigmon/configmap
               - name: {{ include "main.fullname" . }}-certs
                 mountPath: /opt/bigmon/etc/cert
+              {{- if .Values.cvmfs.enabled }}
+              {{- range .Values.cvmfs.repositories }}
+              - name: cvmfs-{{ .name }}
+                mountPath: /cvmfs/{{ .repository }}
+              {{- end }}
+              {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.global.secret }}-bigmon-envs
@@ -138,6 +144,14 @@ spec:
           secret:
               secretName: {{ .Values.global.secret }}-bigmon-certs
           {{- end }}
+        {{- if .Values.cvmfs.enabled }}
+        {{- range .Values.cvmfs.repositories }}
+        - name: cvmfs-{{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "main.fullname" $ }}-cvmfs-{{ .name }}
+            readOnly: true
+        {{- end }}
+        {{- end }}
   {{- if .Values.persistentvolume.create }}
         - name: {{ include "main.fullname" . }}-logs
           persistentVolumeClaim:

--- a/helm/bigmon/charts/main/values.yaml
+++ b/helm/bigmon/charts/main/values.yaml
@@ -123,3 +123,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+cvmfs:
+  enabled: false
+  repositories: []
+  # - name: atlas
+  #   repository: atlas.cern.ch
+  # - name: atlas-condb
+  #   repository: atlas-condb.cern.ch

--- a/helm/bigmon/values/values-atlas_testbed.yaml
+++ b/helm/bigmon/values/values-atlas_testbed.yaml
@@ -16,6 +16,13 @@ main:
   persistentvolume:
     create: true
     size: 50Gi
+  cvmfs:
+    enabled: true
+    repositories:
+      - name: atlas
+        repository: atlas.cern.ch
+      - name: atlas-condb
+        repository: atlas-condb.cern.ch
 
   ingress:
     enabled: true

--- a/helm/harvester/charts/harvester/templates/cvmfs-volumes.yaml
+++ b/helm/harvester/charts/harvester/templates/cvmfs-volumes.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.cvmfs.enabled }}
+{{- range .Values.cvmfs.repositories }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "harvester.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: cvmfs.csi.cern.ch
+    volumeHandle: {{ include "harvester.fullname" $ }}-cvmfs-{{ .name }}
+    volumeAttributes:
+      repository: {{ .repository }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "harvester.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  volumeName: {{ include "harvester.fullname" $ }}-cvmfs-{{ .name }}
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+{{- end }}

--- a/helm/harvester/charts/harvester/templates/statefulset.yaml
+++ b/helm/harvester/charts/harvester/templates/statefulset.yaml
@@ -252,6 +252,12 @@ spec:
             - name: {{ include "harvester.fullname" . }}-special-data
               mountPath: {{ .Values.persistentvolumespecial.path }}
             {{- end }}
+            {{- if .Values.cvmfs.enabled }}
+            {{- range .Values.cvmfs.repositories }}
+            - name: cvmfs-{{ .name }}
+              mountPath: /cvmfs/{{ .repository }}
+            {{- end }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "harvester.fullname" . }}-env
@@ -309,6 +315,14 @@ spec:
         - name: {{ include "harvester.fullname" . }}-wdirs
           persistentVolumeClaim:
             claimName: {{ include "harvester.fullname" . }}-wdirs
+        {{- if .Values.cvmfs.enabled }}
+        {{- range .Values.cvmfs.repositories }}
+        - name: cvmfs-{{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "harvester.fullname" $ }}-cvmfs-{{ .name }}
+            readOnly: true
+        {{- end }}
+        {{- end }}
   {{- if .Values.persistentvolume.create }}
         - name: {{ include "harvester.fullname" . }}-logs
           persistentVolumeClaim:

--- a/helm/harvester/charts/harvester/values.yaml
+++ b/helm/harvester/charts/harvester/values.yaml
@@ -112,3 +112,11 @@ affinity: {}
 
 route:
   enabled: false
+
+cvmfs:
+  enabled: false
+  repositories: []
+  # - name: atlas
+  #   repository: atlas.cern.ch
+  # - name: atlas-condb
+  #   repository: atlas-condb.cern.ch

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -55,6 +55,13 @@ harvester:
     class: manila-meyrin-cephfs
     selector: false
     size: 50Gi
+  cvmfs:
+    enabled: true
+    repositories:
+      - name: atlas
+        repository: atlas.cern.ch
+      - name: atlas-condb
+        repository: atlas-condb.cern.ch
   persistentvolumewdir:
     size: 50Gi
   persistentvolumecondor:

--- a/helm/idds/charts/rest/templates/cvmfs-volumes.yaml
+++ b/helm/idds/charts/rest/templates/cvmfs-volumes.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.cvmfs.enabled }}
+{{- range .Values.cvmfs.repositories }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "rest.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: cvmfs.csi.cern.ch
+    volumeHandle: {{ include "rest.fullname" $ }}-cvmfs-{{ .name }}
+    volumeAttributes:
+      repository: {{ .repository }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rest.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  volumeName: {{ include "rest.fullname" $ }}-cvmfs-{{ .name }}
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+{{- end }}

--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -155,6 +155,12 @@ spec:
                 mountPath: /opt/idds/certs
               - name: {{ include "rest.fullname" . }}-requests
                 mountPath: {{ .Values.persistentvolumerequests.path }}
+              {{- if .Values.cvmfs.enabled }}
+              {{- range .Values.cvmfs.repositories }}
+              - name: cvmfs-{{ .name }}
+                mountPath: /cvmfs/{{ .repository }}
+              {{- end }}
+              {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -183,6 +189,14 @@ spec:
         - name: {{ include "rest.fullname" . }}-requests
           persistentVolumeClaim:
               claimName: {{ include "rest.fullname" . }}-requests
+        {{- if .Values.cvmfs.enabled }}
+        {{- range .Values.cvmfs.repositories }}
+        - name: cvmfs-{{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "rest.fullname" $ }}-cvmfs-{{ .name }}
+            readOnly: true
+        {{- end }}
+        {{- end }}
   {{- if .Values.persistentvolume.create }}
         - name: {{ include "rest.fullname" . }}-logs
           persistentVolumeClaim:

--- a/helm/idds/charts/rest/values.yaml
+++ b/helm/idds/charts/rest/values.yaml
@@ -142,3 +142,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+cvmfs:
+  enabled: false
+  repositories: []
+  # - name: atlas
+  #   repository: atlas.cern.ch
+  # - name: atlas-condb
+  #   repository: atlas-condb.cern.ch

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -17,6 +17,13 @@ rest:
     class: manual
     selector: true
     size: 5Gi
+  cvmfs:
+    enabled: true
+    repositories:
+      - name: atlas
+        repository: atlas.cern.ch
+      - name: atlas-condb
+        repository: atlas-condb.cern.ch
   persistentvolumerequests:
     create: true
     class: manual

--- a/helm/panda/charts/jedi/templates/cvmfs-volumes.yaml
+++ b/helm/panda/charts/jedi/templates/cvmfs-volumes.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.cvmfs.enabled }}
+{{- range .Values.cvmfs.repositories }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "jedi.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: cvmfs.csi.cern.ch
+    volumeHandle: {{ include "jedi.fullname" $ }}-cvmfs-{{ .name }}
+    volumeAttributes:
+      repository: {{ .repository }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jedi.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  volumeName: {{ include "jedi.fullname" $ }}-cvmfs-{{ .name }}
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+{{- end }}

--- a/helm/panda/charts/jedi/templates/statefulset.yaml
+++ b/helm/panda/charts/jedi/templates/statefulset.yaml
@@ -107,6 +107,12 @@ spec:
                 mountPath: /opt/panda/sandbox
               - name: {{ include "jedi.fullname" . }}-certs
                 mountPath: /opt/panda/etc/cert
+              {{- if .Values.cvmfs.enabled }}
+              {{- range .Values.cvmfs.repositories }}
+              - name: cvmfs-{{ .name }}
+                mountPath: /cvmfs/{{ .repository }}
+              {{- end }}
+              {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-server-env
@@ -150,6 +156,14 @@ spec:
                   name: {{ include "jedi.fullname" . }}-configjson
               - configMap:
                   name: {{ .Release.Name }}-server-configjson
+        {{- if .Values.cvmfs.enabled }}
+        {{- range .Values.cvmfs.repositories }}
+        - name: cvmfs-{{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "jedi.fullname" $ }}-cvmfs-{{ .name }}
+            readOnly: true
+        {{- end }}
+        {{- end }}
   {{- if .Values.persistentvolume.create }}
         - name: {{ include "jedi.fullname" . }}-logs
           persistentVolumeClaim:

--- a/helm/panda/charts/jedi/values.yaml
+++ b/helm/panda/charts/jedi/values.yaml
@@ -82,3 +82,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+cvmfs:
+  enabled: false
+  repositories: []
+  # - name: atlas
+  #   repository: atlas.cern.ch
+  # - name: atlas-condb
+  #   repository: atlas-condb.cern.ch

--- a/helm/panda/charts/server/templates/cvmfs-volumes.yaml
+++ b/helm/panda/charts/server/templates/cvmfs-volumes.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.cvmfs.enabled }}
+{{- range .Values.cvmfs.repositories }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "server.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: cvmfs.csi.cern.ch
+    volumeHandle: {{ include "server.fullname" $ }}-cvmfs-{{ .name }}
+    volumeAttributes:
+      repository: {{ .repository }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "server.fullname" $ }}-cvmfs-{{ .name }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: cvmfs
+  volumeName: {{ include "server.fullname" $ }}-cvmfs-{{ .name }}
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+{{- end }}

--- a/helm/panda/charts/server/templates/statefulset.yaml
+++ b/helm/panda/charts/server/templates/statefulset.yaml
@@ -132,6 +132,12 @@ spec:
              - name: {{ include "server.fullname" . }}-cache
                mountPath: /var/log/panda/pandacache
              {{- end }}
+             {{- if .Values.cvmfs.enabled }}
+             {{- range .Values.cvmfs.repositories }}
+             - name: cvmfs-{{ .name }}
+               mountPath: /cvmfs/{{ .repository }}
+             {{- end }}
+             {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "server.fullname" . }}-env
@@ -195,6 +201,14 @@ spec:
         - name: {{ include "server.fullname" . }}-cache
           persistentVolumeClaim:
             claimName: {{ include "server.fullname" . }}
+        {{- end }}
+        {{- if .Values.cvmfs.enabled }}
+        {{- range .Values.cvmfs.repositories }}
+        - name: cvmfs-{{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "server.fullname" $ }}-cvmfs-{{ .name }}
+            readOnly: true
+        {{- end }}
         {{- end }}
   {{- if .Values.persistentvolume.create }}
         - name: {{ include "server.fullname" . }}-logs

--- a/helm/panda/charts/server/values.yaml
+++ b/helm/panda/charts/server/values.yaml
@@ -191,3 +191,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+cvmfs:
+  enabled: false
+  repositories: []
+  # - name: atlas
+  #   repository: atlas.cern.ch
+  # - name: atlas-condb
+  #   repository: atlas-condb.cern.ch

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -66,6 +66,13 @@ server:
     class: manila-meyrin-cephfs
     selector: false
     size: 50Gi
+  cvmfs:
+    enabled: true
+    repositories:
+      - name: atlas
+        repository: atlas.cern.ch
+      - name: atlas-condb
+        repository: atlas-condb.cern.ch
   # use Route class for ingress
   route:
     enabled: false
@@ -132,6 +139,13 @@ jedi:
     class: manila-meyrin-cephfs
     selector: false
     size: 50Gi
+  cvmfs:
+    enabled: true
+    repositories:
+      - name: atlas
+        repository: atlas.cern.ch
+      - name: atlas-condb
+        repository: atlas-condb.cern.ch
 
 nodeRecovery:
   enabled: true


### PR DESCRIPTION
## Summary

- Adds opt-in CVMFS volume support to all five PanDA component charts (server, jedi, harvester, idds-rest, bigmon)
- Each chart gets a new `cvmfs-volumes.yaml` template that creates static PVs + PVCs via the `cvmfs.csi.cern.ch` CSI driver (Persistent mode — ephemeral inline CSI is not supported by the CERN driver)
- The StatefulSet mounts the PVCs at `/cvmfs/<repository>` using `ReadOnlyMany` access
- Feature is **disabled by default** (`cvmfs.enabled: false` in each chart's `values.yaml`)
- Enabled for the ATLAS testbed in `values-atlas_testbed.yaml` for each chart, mounting `atlas.cern.ch` and `atlas-condb.cern.ch`

## Configuration

To enable for a deployment, add to the relevant values file:
```yaml
cvmfs:
  enabled: true
  repositories:
    - name: atlas
      repository: atlas.cern.ch
    - name: atlas-condb
      repository: atlas-condb.cern.ch
```

## Test plan

- [x] Verified `cvmfs.csi.cern.ch` CSI driver is installed and running on testbed (DaemonSet on all 8 nodes)
- [x] Verified static PV + PVC approach works: test pod successfully listed `/cvmfs/atlas.cern.ch` contents
- [x] `helm template` renders correctly for all 5 charts with testbed values
- [ ] After merge + ArgoCD sync: `kubectl get pvc | grep cvmfs` → 10 PVCs Bound (2 repos × 5 components)
- [ ] `kubectl exec panda-server-0 -- ls /cvmfs/atlas.cern.ch` → ATLAS software tree visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)