### PR TITLE
bump(panda): update panda-server and panda-jedi to 0.8.1

### DIFF
--- a/helm/panda/values.yaml
+++ b/helm/panda/values.yaml
@@ -11,7 +11,7 @@ jedi:
 
   # container image and tag
   image:
-    tag: "0.7.2"
+    tag: "0.8.1"
     # tag: "master"
 
   # PV with selector support
@@ -32,7 +32,7 @@ server:
 
   # container image and tag
   image:
-    tag: "0.7.2"
+    tag: "0.8.1"
     # tag: "master"
 
   # PV with selector support


### PR DESCRIPTION
## Summary
- Bumps `panda-server` image tag from `0.7.2` → `0.8.1`
- Bumps `panda-jedi` image tag from `0.7.2` → `0.8.1`

Both use the same monorepo Docker image (`ghcr.io/pandawms/panda-server`).

## Test plan
- [ ] ArgoCD auto-syncs on testbed after merge
- [ ] `panda-server-0` and `panda-jedi-0` pods restart on new image
- [ ] Verify pods reach Running state