### PR TITLE
fix(server): remove redundant ssl.conf deletion workaround

### DIFF
--- a/helm/panda/charts/server/templates/statefulset.yaml
+++ b/helm/panda/charts/server/templates/statefulset.yaml
@@ -94,7 +94,6 @@ spec:
                   ln -s /opt/panda/sandbox/panda_server-httpd.conf /opt/panda/etc/panda/panda_server-httpd.conf;
                fi;
               /opt/panda/bin/python /data/panda/process_template.py;
-              rm -f /etc/httpd/conf.d/ssl.conf;
               /opt/panda/bin/panda_common-install_igtf_ca;
               /data/panda/run-panda-services;
               sleep infinity & wait


### PR DESCRIPTION
## Summary
- Removes `rm -f /etc/httpd/conf.d/ssl.conf` from the server startup command

## Background
This line was added in #195 to work around the OS httpd RPM shipping a default `ssl.conf` that references a non-existent `localhost.crt`, causing Apache to crash on startup. The fix has since been incorporated into the panda-server image itself (PanDAWMS/panda-server#695, released in 0.8.1), making this workaround redundant.

## Test plan
- [ ] Verify `panda-server-0` starts cleanly after merge (no Apache crash on startup)