### PR TITLE
feat: migrate BigMon logs to shared CephFS volume

### DIFF
--- a/helm/bigmon/charts/main/templates/statefulset.yaml
+++ b/helm/bigmon/charts/main/templates/statefulset.yaml
@@ -96,6 +96,9 @@ spec:
           volumeMounts:
               - name: {{ include "main.fullname" . }}-logs
                 mountPath: /data/bigmon/logs
+                {{- if .Values.persistentvolume.subPath }}
+                subPath: {{ .Values.persistentvolume.subPath }}
+                {{- end }}
               - name: {{ include "main.fullname" . }}-sandbox
                 mountPath: /data/bigmon/configmap
               - name: {{ include "main.fullname" . }}-certs
@@ -156,6 +159,10 @@ spec:
         - name: {{ include "main.fullname" . }}-logs
           persistentVolumeClaim:
             claimName: {{ include "main.fullname" . }}
+  {{- else if .Values.persistentvolume.sharedPvcName }}
+        - name: {{ include "main.fullname" . }}-logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistentvolume.sharedPvcName }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/helm/bigmon/charts/main/values.yaml
+++ b/helm/bigmon/charts/main/values.yaml
@@ -13,10 +13,12 @@ image:
 autoStart: true
 
 persistentvolume:
-  create: false  
+  create: false
   path: "/mnt/bigmon-main-logs"
   size: 5Gi
   selector: true
+  sharedPvcName: ""
+  subPath: ""
 
 # hostname for external access
 hostName: "FIXME"

--- a/helm/bigmon/values/values-atlas_testbed.yaml
+++ b/helm/bigmon/values/values-atlas_testbed.yaml
@@ -14,7 +14,9 @@ main:
       effect: "NoExecute"
       tolerationSeconds: 30
   persistentvolume:
-    create: true
+    create: false
+    sharedPvcName: panda-shared-logs
+    subPath: bigmon-logs
     size: 50Gi
   cvmfs:
     enabled: true

--- a/helm/harvester/charts/harvester/templates/statefulset.yaml
+++ b/helm/harvester/charts/harvester/templates/statefulset.yaml
@@ -95,6 +95,7 @@ spec:
     path: {{ .Values.persistentvolumecondor.path }}
 ---
 {{- end }}
+{{- if not .Values.persistentvolumecondor.existingClaim }}
 # pv claim for condor logs
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -115,6 +116,55 @@ spec:
       {{- include "harvester.selectorLabels-condor-logs" . | nindent 6 }}
   {{- end }}
 ---
+{{- end }}
+{{- if .Values.sharedLogs.create }}
+# shared logs pv
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.sharedLogs.name }}
+spec:
+  storageClassName: manila-meyrin-cephfs
+  capacity:
+    storage: {{ .Values.sharedLogs.size }}
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.sharedLogs.name }}
+  csi:
+    driver: cephfs.manila.csi.openstack.org
+    volumeHandle: {{ .Values.sharedLogs.shareID }}
+    nodeStageSecretRef:
+      name: os-trustee
+      namespace: kube-system
+    nodePublishSecretRef:
+      name: os-trustee
+      namespace: kube-system
+    controllerExpandSecretRef:
+      name: os-trustee
+      namespace: kube-system
+    volumeAttributes:
+      shareID: {{ .Values.sharedLogs.shareID }}
+      shareAccessID: {{ .Values.sharedLogs.shareAccessID }}
+      cephfs-mounter: fuse
+---
+# shared logs pvc
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.sharedLogs.name }}
+spec:
+  storageClassName: manila-meyrin-cephfs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.sharedLogs.size }}
+  volumeName: {{ .Values.sharedLogs.name }}
+---
+{{- end }}
 
 # special mount data
 {{- if .Values.persistentvolumespecial.mount }}
@@ -234,6 +284,9 @@ spec:
               mountPath: /var/log/harvester_wdirs/
             - name: {{ include "harvester.fullname" . }}-condor-logs
               mountPath: /var/log/condor_logs/
+              {{- if .Values.persistentvolumecondor.subPath }}
+              subPath: {{ .Values.persistentvolumecondor.subPath }}
+              {{- end }}
             - name: {{ include "harvester.fullname" . }}-configjson
               mountPath: /opt/harvester/etc/configmap
             - name: {{ include "harvester.fullname" . }}-queueconfig
@@ -297,7 +350,7 @@ spec:
               secretName: {{ .Values.global.secret }}-harvester-auth
         - name: {{ include "harvester.fullname" . }}-condor-logs
           persistentVolumeClaim:
-            claimName: {{ include "harvester.fullname" . }}-condor-logs
+            claimName: {{ .Values.persistentvolumecondor.existingClaim | default (printf "%s-condor-logs" (include "harvester.fullname" .)) }}
         {{- if .Values.persistentvolumespecial.mount }}
         - name: {{ include "harvester.fullname" . }}-special-data
           persistentVolumeClaim:

--- a/helm/harvester/charts/harvester/values.yaml
+++ b/helm/harvester/charts/harvester/values.yaml
@@ -50,6 +50,15 @@ persistentvolumecondor:
   path: "/mnt/harvester-condor-logs"
   size: 5Gi
   selector: true
+  existingClaim: ""
+  subPath: ""
+
+sharedLogs:
+  create: false
+  name: ""
+  size: 50Gi
+  shareID: ""
+  shareAccessID: ""
 
 persistentvolumespecial:
   mount: false

--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -65,10 +65,14 @@ harvester:
   persistentvolumewdir:
     size: 50Gi
   persistentvolumecondor:
-    create: false
-    class: manila-meyrin-cephfs
-    selector: false
+    existingClaim: panda-shared-logs
+    subPath: condor_logs
+  sharedLogs:
+    create: true
+    name: panda-shared-logs
     size: 50Gi
+    shareID: c94d44ca-e58e-4012-bb8d-3bd58242af90
+    shareAccessID: a914f98d-2d71-407c-b291-33e37c34b862
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
## Summary

- **BigMon** (ATLAS testbed): moves logs off hostPath (`/mnt/bigmon-main-logs` on node disk) onto the shared CephFS volume `panda-shared-logs` at `subPath: bigmon-logs`
- **Harvester** (ATLAS testbed): condor logs move to `panda-shared-logs` at `subPath: condor_logs` — repurposing the existing `panda-harvester-condor-logs` Manila share to stay within the 10-share OpenStack quota
- All new chart options default to empty/false — no impact on non-CERN deployments (LSST, sPHENIX, etc.)

## Chart changes

### harvester chart
- `persistentvolumecondor.existingClaim`: when set, skips PVC creation and uses that claim name
- `persistentvolumecondor.subPath`: optional subPath on the condor logs volumeMount
- `sharedLogs.create/name/size/shareID/shareAccessID`: creates a static PV+PVC pointing to an existing Manila CephFS share (no new share consumed)

### bigmon chart
- `persistentvolume.sharedPvcName`: third branch alongside `create: true` (hostPath) and `volumeClaimTemplates` — mounts an external PVC
- `persistentvolume.subPath`: optional subPath on the logs volumeMount

## ATLAS testbed values
- Harvester condor logs → `panda-shared-logs/condor_logs` (same underlying CephFS share, new PVC name)
- BigMon logs → `panda-shared-logs/bigmon-logs` (off hostPath, onto CephFS)

## Post-merge migration steps (testbed only)
After ArgoCD syncs:
1. Verify `panda-shared-logs` PVC is Bound: `kubectl get pvc panda-shared-logs`
2. Verify BigMon pod mounts CephFS: `kubectl exec panda-bigmon-main-0 -- df -h /data/bigmon/logs`
3. Delete the orphaned old PVC/PV: `kubectl delete pvc panda-harvester-condor-logs && kubectl delete pv pvc-7aedac5f-6d4a-4b27-b57f-43e172cb4a30`
4. Delete the orphaned BigMon hostPath PVC/PV: `kubectl delete pvc panda-bigmon-main && kubectl delete pv panda-bigmon-main`
