### PR TITLE
feat: migrate DOMA logs to shared CephFS volume

### DIFF
--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -5,9 +5,9 @@
 
 main:
   persistentvolume:
-    create: true
-    class: manual
-    path: "/mnt/bigmon-main-logs"
+    create: false
+    sharedPvcName: panda-shared-logs
+    subPath: bigmon-logs
     size: 50Gi
 
   ingress:

--- a/helm/harvester/charts/harvester/templates/statefulset.yaml
+++ b/helm/harvester/charts/harvester/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 # pv
-{{- if .Values.persistentvolume.create }}
+{{- if and .Values.persistentvolume.create (not .Values.persistentvolume.existingClaim) }}
 kind: PersistentVolume
 apiVersion: v1
 metadata:
@@ -56,6 +56,7 @@ spec:
     path: {{ .Values.persistentvolume.path }}
 ---
 {{- end }}
+{{- if not .Values.persistentvolumewdir.existingClaim }}
 # pv claim
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -76,6 +77,7 @@ spec:
       {{- include "harvester.selectorLabels-wdirs" . | nindent 6 }}
   {{- end }}
 ---
+{{- end }}
 # pv for condor logs
 {{- if .Values.persistentvolumecondor.create }}
 kind: PersistentVolume
@@ -118,7 +120,8 @@ spec:
 ---
 {{- end }}
 {{- if .Values.sharedLogs.create }}
-# shared logs pv
+{{- if .Values.sharedLogs.shareID }}
+# shared logs pv (static - existing Manila share)
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -150,7 +153,7 @@ spec:
       shareAccessID: {{ .Values.sharedLogs.shareAccessID }}
       cephfs-mounter: fuse
 ---
-# shared logs pvc
+# shared logs pvc (static)
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -163,6 +166,20 @@ spec:
     requests:
       storage: {{ .Values.sharedLogs.size }}
   volumeName: {{ .Values.sharedLogs.name }}
+{{- else }}
+# shared logs pvc (dynamic)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.sharedLogs.name }}
+spec:
+  storageClassName: {{ .Values.sharedLogs.storageClass }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.sharedLogs.size }}
+{{- end }}
 ---
 {{- end }}
 
@@ -280,8 +297,14 @@ spec:
           volumeMounts:
             - name: {{ include "harvester.fullname" . }}-logs
               mountPath: /var/log/panda/
+              {{- if .Values.persistentvolume.subPath }}
+              subPath: {{ .Values.persistentvolume.subPath }}
+              {{- end }}
             - name: {{ include "harvester.fullname" . }}-wdirs
               mountPath: /var/log/harvester_wdirs/
+              {{- if .Values.persistentvolumewdir.subPath }}
+              subPath: {{ .Values.persistentvolumewdir.subPath }}
+              {{- end }}
             - name: {{ include "harvester.fullname" . }}-condor-logs
               mountPath: /var/log/condor_logs/
               {{- if .Values.persistentvolumecondor.subPath }}
@@ -367,7 +390,7 @@ spec:
           emptyDir: {}
         - name: {{ include "harvester.fullname" . }}-wdirs
           persistentVolumeClaim:
-            claimName: {{ include "harvester.fullname" . }}-wdirs
+            claimName: {{ .Values.persistentvolumewdir.existingClaim | default (printf "%s-wdirs" (include "harvester.fullname" .)) }}
         {{- if .Values.cvmfs.enabled }}
         {{- range .Values.cvmfs.repositories }}
         - name: cvmfs-{{ .name }}
@@ -376,7 +399,11 @@ spec:
             readOnly: true
         {{- end }}
         {{- end }}
-  {{- if .Values.persistentvolume.create }}
+  {{- if .Values.persistentvolume.existingClaim }}
+        - name: {{ include "harvester.fullname" . }}-logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistentvolume.existingClaim }}
+  {{- else if .Values.persistentvolume.create }}
         - name: {{ include "harvester.fullname" . }}-logs
           persistentVolumeClaim:
             claimName: {{ include "harvester.fullname" . }}

--- a/helm/harvester/charts/harvester/values.yaml
+++ b/helm/harvester/charts/harvester/values.yaml
@@ -36,6 +36,8 @@ persistentvolume:
   path: "/mnt/harvester-logs"
   size: 5Gi
   selector: true
+  existingClaim: ""
+  subPath: ""
 
 persistentvolumewdir:
   create: true
@@ -43,6 +45,8 @@ persistentvolumewdir:
   path: "/mnt/harvester-condor-logs"
   size: 5Gi
   selector: true
+  existingClaim: ""
+  subPath: ""
 
 persistentvolumecondor:
   create: true
@@ -59,6 +63,7 @@ sharedLogs:
   size: 50Gi
   shareID: ""
   shareAccessID: ""
+  storageClass: ""
 
 persistentvolumespecial:
   mount: false

--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -4,22 +4,28 @@
 harvester:
   experiment: doma
 
-  # DOMA uses static hostPath PVs on node-3
   persistentvolume:
-    create: true
-    class: manual
-    path: "/mnt/harvester-logs"
+    create: false
     selector: false
     size: 50Gi
+    existingClaim: panda-shared-logs
+    subPath: harvester-logs
   persistentvolumewdir:
     selector: false
     size: 50Gi
+    existingClaim: panda-shared-logs
+    subPath: harvester-wdirs
   persistentvolumecondor:
-    create: true
-    class: manual
-    path: "/mnt/harvester-logs"
+    create: false
     selector: false
     size: 5Gi
+    existingClaim: panda-shared-logs
+    subPath: condor-logs
+  sharedLogs:
+    create: true
+    name: panda-shared-logs
+    size: 100Gi
+    storageClass: manila-meyrin-cephfs
 
   nodeSelector:
     kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3

--- a/helm/panda/charts/jedi/templates/statefulset.yaml
+++ b/helm/panda/charts/jedi/templates/statefulset.yaml
@@ -101,6 +101,9 @@ spec:
           volumeMounts:
               - name: {{ include "jedi.fullname" . }}-logs
                 mountPath: /var/log/panda
+                {{- if .Values.persistentvolume.subPath }}
+                subPath: {{ .Values.persistentvolume.subPath }}
+                {{- end }}
               - name: {{ include "jedi.fullname" . }}-configjson
                 mountPath: /opt/panda/etc/config_json
               - name: {{ include "jedi.fullname" . }}-sandbox
@@ -168,6 +171,10 @@ spec:
         - name: {{ include "jedi.fullname" . }}-logs
           persistentVolumeClaim:
             claimName: {{ include "jedi.fullname" . }}
+  {{- else if .Values.persistentvolume.sharedPvcName }}
+        - name: {{ include "jedi.fullname" . }}-logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistentvolume.sharedPvcName }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/helm/panda/charts/jedi/values.yaml
+++ b/helm/panda/charts/jedi/values.yaml
@@ -21,6 +21,8 @@ persistentvolume:
   path: "/mnt/panda-jedi-logs"
   size: 5Gi
   selector: true
+  sharedPvcName: ""
+  subPath: ""
 
 
 server: {}

--- a/helm/panda/charts/server/templates/statefulset.yaml
+++ b/helm/panda/charts/server/templates/statefulset.yaml
@@ -117,6 +117,9 @@ spec:
           volumeMounts:
              - name: {{ include "server.fullname" . }}-logs
                mountPath: /var/log/panda
+               {{- if .Values.persistentvolume.subPath }}
+               subPath: {{ .Values.persistentvolume.subPath }}
+               {{- end }}
              - name: {{ include "server.fullname" . }}-configjson
                mountPath: /opt/panda/etc/config_json
              - name: {{ include "server.fullname" . }}-auth
@@ -213,6 +216,10 @@ spec:
         - name: {{ include "server.fullname" . }}-logs
           persistentVolumeClaim:
             claimName: {{ include "server.fullname" . }}
+  {{- else if .Values.persistentvolume.sharedPvcName }}
+        - name: {{ include "server.fullname" . }}-logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistentvolume.sharedPvcName }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/helm/panda/charts/server/values.yaml
+++ b/helm/panda/charts/server/values.yaml
@@ -30,6 +30,8 @@ persistentvolume:
   path: "/mnt/panda-server-logs"
   size: 5Gi
   selector: true
+  sharedPvcName: ""
+  subPath: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -23,6 +23,8 @@ server:
     create: false
     selector: false
     size: 50Gi
+    sharedPvcName: panda-shared-logs
+    subPath: server-logs
   configFile: "panda_server_config.cern.json"
   resources:
     requests:
@@ -37,6 +39,8 @@ jedi:
     create: false
     selector: false
     size: 50Gi
+    sharedPvcName: panda-shared-logs
+    subPath: jedi-logs
   configFile: "panda_jedi_config.cern.json"
   resources:
     requests:


### PR DESCRIPTION
## Summary

- **panda-server / panda-jedi**: logs move to `panda-shared-logs` at `subPath: server-logs` / `jedi-logs`
- **BigMon** (DOMA): logs move to `panda-shared-logs` at `subPath: bigmon-logs` — off hostPath
- **Harvester** (DOMA): logs, wdirs, and condor logs all move to `panda-shared-logs` at `subPath: harvester-logs`, `harvester-wdirs`, `condor-logs`
- `panda-shared-logs` is a single 100 Gi PVC provisioned dynamically via `manila-meyrin-cephfs` storageClass — one Manila share consumed

## Chart changes

### server / jedi charts
- `persistentvolume.sharedPvcName`: when set, mounts that existing PVC instead of creating a volumeClaimTemplate
- `persistentvolume.subPath`: optional subPath on the logs volumeMount

### harvester chart
- `persistentvolume.existingClaim` / `subPath`: same existingClaim pattern for main harvester logs
- `persistentvolumewdir.existingClaim` / `subPath`: same pattern for wdirs volume
- `sharedLogs.storageClass`: when set (and `shareID` is empty), creates a dynamically provisioned PVC instead of a static CephFS PV

All new options default to empty — no impact on non-CERN deployments (LSST, sPHENIX, etc.) or the ATLAS testbed.

## DOMA values (`values-cern.yaml`)

| App | Old storage | New storage |
|---|---|---|
| panda-server | hostPath `/var/log/panda` via volumeClaimTemplate | `panda-shared-logs/server-logs` |
| panda-jedi | hostPath `/var/log/panda` via volumeClaimTemplate | `panda-shared-logs/jedi-logs` |
| panda-bigmon | hostPath `/mnt/bigmon-main-logs` | `panda-shared-logs/bigmon-logs` |
| panda-harvester logs | hostPath `/mnt/harvester-logs` | `panda-shared-logs/harvester-logs` |
| harvester wdirs | hostPath `/mnt/harvester-logs` | `panda-shared-logs/harvester-wdirs` |
| harvester condor logs | hostPath `/mnt/harvester-logs` | `panda-shared-logs/condor-logs` |

## Post-merge migration steps (DOMA only)
After ArgoCD syncs:
1. Verify `panda-shared-logs` PVC is Bound: `kubectl get pvc panda-shared-logs`
2. Verify pods mount CephFS: `kubectl exec panda-server-0 -- df -h /var/log/panda`
3. Delete orphaned hostPath PVs that ArgoCD pruned (they will be in Released state)