### PR TITLE
fix(doma): revert CephFS migration, restore hostPath (Manila quota exceeded)

### DIFF
--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -5,9 +5,9 @@
 
 main:
   persistentvolume:
-    create: false
-    sharedPvcName: panda-shared-logs
-    subPath: bigmon-logs
+    create: true
+    class: manual
+    path: "/mnt/bigmon-main-logs"
     size: 50Gi
 
   ingress:

--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -4,28 +4,22 @@
 harvester:
   experiment: doma
 
+  # DOMA uses static hostPath PVs on node-3
   persistentvolume:
-    create: false
+    create: true
+    class: manual
+    path: "/mnt/harvester-logs"
     selector: false
     size: 50Gi
-    existingClaim: panda-shared-logs
-    subPath: harvester-logs
   persistentvolumewdir:
     selector: false
     size: 50Gi
-    existingClaim: panda-shared-logs
-    subPath: harvester-wdirs
   persistentvolumecondor:
-    create: false
+    create: true
+    class: manual
+    path: "/mnt/harvester-logs"
     selector: false
     size: 5Gi
-    existingClaim: panda-shared-logs
-    subPath: condor-logs
-  sharedLogs:
-    create: true
-    name: panda-shared-logs
-    size: 100Gi
-    storageClass: manila-meyrin-cephfs
 
   nodeSelector:
     kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -23,8 +23,6 @@ server:
     create: false
     selector: false
     size: 50Gi
-    sharedPvcName: panda-shared-logs
-    subPath: server-logs
   configFile: "panda_server_config.cern.json"
   resources:
     requests:
@@ -39,8 +37,6 @@ jedi:
     create: false
     selector: false
     size: 50Gi
-    sharedPvcName: panda-shared-logs
-    subPath: jedi-logs
   configFile: "panda_jedi_config.cern.json"
   resources:
     requests:

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -23,6 +23,7 @@ server:
     create: false
     selector: false
     size: 50Gi
+    sharedPvcName: panda-server-logs
   configFile: "panda_server_config.cern.json"
   resources:
     requests:
@@ -37,6 +38,7 @@ jedi:
     create: false
     selector: false
     size: 50Gi
+    sharedPvcName: panda-jedi-logs
   configFile: "panda_jedi_config.cern.json"
   resources:
     requests:


### PR DESCRIPTION
## What happened

PR #223 was merged but immediately failed: the DOMA cluster's OpenStack project has a **10-share Manila CephFS limit** that is already full. `panda-shared-logs` provisioning returned `ShareLimitExceeded: Maximum number of shares allowed (10)`.

Additionally, the `sharedPvcName: panda-shared-logs` + `subPath: server-logs/jedi-logs` combination broke panda-server and panda-jedi because their existing hostPath PVs store logs directly (no `server-logs/` subdirectory).

## What this PR does

1. **Reverts** bigmon and harvester values-cern.yaml to hostPath (`create: true`), removing the `sharedLogs` dynamic provisioner config
2. **Fixes** server and jedi by pointing them at new dedicated PVCs (`panda-server-logs`, `panda-jedi-logs`) that were manually created and bound to the pre-existing hostPath PVs — no subPath

The chart options added in #223 (sharedPvcName, existingClaim, subPath, sharedLogs.storageClass) remain in place for future use once the Manila quota is resolved.

## Urgency

DOMA is currently down (server, jedi, bigmon, harvester all degraded). Please merge immediately.

## Next steps

To enable CephFS for DOMA in the future: request a Manila quota increase for the `ATLAS Services PANDA` OpenStack project (current limit: 10 CephFS shares, all consumed by testbed).