### PR TITLE
fix(bigmon): use chmod -R to fix permissions on existing log files

### DIFF
--- a/helm/bigmon/charts/main/templates/statefulset.yaml
+++ b/helm/bigmon/charts/main/templates/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
               mv /data/bigmon/config/rucio.cfg /opt/bigmon/etc/ ;
               {{- if .Values.autoStart }}
               if [ "${PANDA_DB_BACKEND}" != "oracle" ]; then until /usr/pgsql-*/bin/pg_isready -h ${PANDA_DB_HOST} -p ${PANDA_DB_PORT}; do echo waiting for database; sleep 2; done; fi;
-              chmod 777 /data/bigmon/logs;
+              chmod -R 777 /data/bigmon/logs;
               start-daemon.sh all
               {{- else }}
               sleep infinity & wait


### PR DESCRIPTION
## Summary

- Change `chmod 777 /data/bigmon/logs` to `chmod -R 777 /data/bigmon/logs` in the bigmon StatefulSet startup command

## Problem

When a bigmon pod restarts against a hostPath PVC that already has log files, existing files (e.g. `logfile.django` created by root during a previous startup) retain their old ownership/permissions. Without `-R`, only the directory is chmod'd. The Apache worker (running as `apache`) then fails to write to `logfile.django`, causing:

```
PermissionError: [Errno 13] Permission denied: '/data/bigmon/logs/logfile.django'
ValueError: Unable to configure handler 'logfile-django'
```

This produces an internal server error on every request until permissions are fixed manually.

## Fix

Adding `-R` ensures all existing files in the logs directory are also made world-writable before Apache starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)