### PR TITLE
feat(atlas-testbed): consolidate all logs onto panda-shared-logs (200Gi)

### DIFF
--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -52,8 +52,8 @@ harvester:
             topologyKey: kubernetes.io/hostname
   persistentvolume:
     create: false
-    class: manila-meyrin-cephfs
-    selector: false
+    existingClaim: panda-shared-logs
+    subPath: harvester-logs
     size: 50Gi
   cvmfs:
     enabled: true
@@ -71,7 +71,7 @@ harvester:
   sharedLogs:
     create: true
     name: panda-shared-logs
-    size: 50Gi
+    size: 200Gi
     shareID: c94d44ca-e58e-4012-bb8d-3bd58242af90
     shareAccessID: a914f98d-2d71-407c-b291-33e37c34b862
   resources:

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -63,8 +63,8 @@ server:
       memory: 10Gi
   persistentvolume:
     create: false
-    class: manila-meyrin-cephfs
-    selector: false
+    sharedPvcName: panda-shared-logs
+    subPath: server-logs
     size: 50Gi
   cvmfs:
     enabled: true
@@ -136,8 +136,8 @@ jedi:
       memory: 10Gi
   persistentvolume:
     create: false
-    class: manila-meyrin-cephfs
-    selector: false
+    sharedPvcName: panda-shared-logs
+    subPath: jedi-logs
     size: 50Gi
   cvmfs:
     enabled: true


### PR DESCRIPTION
## Summary

- Route server, jedi, and harvester logs to `panda-shared-logs` via subPaths, reducing Manila CephFS share count from **5 → 2** on the atlas testbed
- Resize `panda-shared-logs` PV/PVC from 50Gi → 200Gi (OpenStack share already resized)
- Frees 3 Manila shares for the future DOMA CephFS migration

| Component | Before | After |
|---|---|---|
| panda-server | dedicated 50Gi CephFS PVC (VCT) | `panda-shared-logs/server-logs` |
| panda-jedi | dedicated 50Gi CephFS PVC (VCT) | `panda-shared-logs/jedi-logs` |
| panda-harvester | dedicated 50Gi CephFS PVC (VCT) | `panda-shared-logs/harvester-logs` |
| bigmon | `panda-shared-logs/bigmon-logs` | unchanged |
| harvester condor | `panda-shared-logs/condor_logs` | unchanged |
| harvester wdirs | dedicated 50Gi CephFS PVC | unchanged |

## Migration steps after merge + ArgoCD sync

StatefulSets with `volumeClaimTemplates` cannot be updated in-place — delete them (keeping pods running) and let ArgoCD recreate without VCTs:

```bash
kubectl delete sts panda-server panda-jedi panda-harvester --cascade=orphan
# ArgoCD sync recreates the StatefulSets pointing to panda-shared-logs
kubectl delete pvc panda-server-logs-panda-server-0 \
                   panda-jedi-logs-panda-jedi-0 \
                   panda-harvester-logs-panda-harvester-0
```

The 3 released PVs (`pvc-d805534c`, `pvc-02ae1a0a`, `pvc-d73c6e6b`) and their underlying Manila shares can then be deleted from OpenStack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)