### PR TITLE
fix(atlas-testbed): revert harvester logs to dedicated CephFS PVC

### DIFF
--- a/helm/harvester/values/values-atlas_testbed.yaml
+++ b/helm/harvester/values/values-atlas_testbed.yaml
@@ -52,8 +52,8 @@ harvester:
             topologyKey: kubernetes.io/hostname
   persistentvolume:
     create: false
-    existingClaim: panda-shared-logs
-    subPath: harvester-logs
+    class: manila-meyrin-cephfs
+    selector: false
     size: 50Gi
   cvmfs:
     enabled: true


### PR DESCRIPTION
The Manila CephFS CSI driver hangs when the same PVC is mounted twice in the same pod. Harvester needs `panda-shared-logs` for both condor-logs and (after PR #226) for its main logs — two mounts of the same PVC caused `panda-harvester-0` to be stuck in ContainerCreating indefinitely.

Revert harvester logs to its own dynamic CephFS PVC. Server and jedi remain consolidated on `panda-shared-logs`, so we still go from 5 Manila shares to 3.