### PR TITLE
feat(doma): migrate all logs to CephFS panda-shared-logs (200Gi)

### DIFF
--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -5,9 +5,9 @@
 
 main:
   persistentvolume:
-    create: true
-    class: manual
-    path: "/mnt/bigmon-main-logs"
+    create: false
+    sharedPvcName: panda-shared-logs
+    subPath: bigmon-logs
     size: 50Gi
 
   ingress:

--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -4,11 +4,11 @@
 harvester:
   experiment: doma
 
-  # DOMA uses static hostPath PVs on node-3
   persistentvolume:
-    create: true
-    class: manual
-    path: "/mnt/harvester-logs"
+    create: false
+    class: manila-meyrin-cephfs
+    existingClaim: panda-shared-logs
+    subPath: harvester-logs
     selector: false
     size: 50Gi
   persistentvolumewdir:
@@ -20,6 +20,11 @@ harvester:
     path: "/mnt/harvester-logs"
     selector: false
     size: 5Gi
+  sharedLogs:
+    create: true
+    name: panda-shared-logs
+    size: 100Gi
+    storageClass: manila-meyrin-cephfs
 
   nodeSelector:
     kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3

--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -23,7 +23,7 @@ harvester:
   sharedLogs:
     create: true
     name: panda-shared-logs
-    size: 100Gi
+    size: 200Gi
     storageClass: manila-meyrin-cephfs
 
   nodeSelector:
@@ -39,11 +39,10 @@ harvester:
 
 mariadb:
   persistentvolume:
-    create: true
-    class: manual
-    path: "/mnt/harvester-data"
+    create: false
     selector: false
-    size: 5Gi
+    existingClaim: panda-harvester-wdirs
+    subPath: mariadb-data
 
   nodeSelector:
     kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -23,7 +23,8 @@ server:
     create: false
     selector: false
     size: 50Gi
-    sharedPvcName: panda-server-logs
+    sharedPvcName: panda-shared-logs
+    subPath: server-logs
   configFile: "panda_server_config.cern.json"
   resources:
     requests:
@@ -38,7 +39,8 @@ jedi:
     create: false
     selector: false
     size: 50Gi
-    sharedPvcName: panda-jedi-logs
+    sharedPvcName: panda-shared-logs
+    subPath: jedi-logs
   configFile: "panda_jedi_config.cern.json"
   resources:
     requests:


### PR DESCRIPTION
Consolidate DOMA logs onto a single dynamic Manila CephFS share using subPaths, reducing Manila share count from 0 to 2 (well within the 10-share project quota shared with the atlas testbed, which uses 3).

## Storage layout after migration

| Component | Volume | Share |
|---|---|---|
| panda-server | panda-shared-logs/server-logs | panda-shared-logs (200Gi) |
| panda-jedi | panda-shared-logs/jedi-logs | panda-shared-logs (200Gi) |
| bigmon | panda-shared-logs/bigmon-logs | panda-shared-logs (200Gi) |
| harvester logs | panda-shared-logs/harvester-logs | panda-shared-logs (200Gi) |
| harvester wdirs | panda-harvester-wdirs | new 50Gi CephFS PVC |
| mariadb | panda-harvester-wdirs/mariadb-data | panda-harvester-wdirs (50Gi) |
| harvester condor-logs | hostPath /mnt/harvester-logs | — (kept on hostPath to avoid double-mount of panda-shared-logs) |

`panda-shared-logs` is created dynamically by the harvester `sharedLogs` block (no pre-existing Manila share ID needed).

Note: existing MariaDB data on hostPath is not migrated — harvester will start with a fresh DB and re-sync job state from PanDA server.

## Migration steps after merge + ArgoCD sync

```bash
export KUBECONFIG=~/cernbox/doma-k8s/config

# Harvester StatefulSet must be recreated (wdirs storage class changes from manual to CephFS)
kubectl delete sts panda-harvester --cascade=orphan
kubectl delete pod panda-harvester-0

# Old panda-harvester-wdirs PVC is manual/hostPath; storage class can't be changed in-place
kubectl delete pvc panda-harvester-wdirs

# Trigger ArgoCD sync to recreate StatefulSet + provision new CephFS PVCs
argocd app sync panda-harvester --insecure
```

Server, jedi, and bigmon only change their `sharedPvcName` — no StatefulSet deletion needed, pods restart automatically.

The old hostPath PVs/PVCs (panda-server-logs, panda-jedi-logs, panda-bigmon-main, panda-harvester, panda-harvester-wdirs, panda-harvester-condor-logs, panda-mariadb) will be pruned by ArgoCD or can be deleted manually after the pods are healthy.