### PR TITLE
DOMA: mount harvester wdirs and mariadb on panda-shared-logs

### DIFF
--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -12,6 +12,8 @@ harvester:
     selector: false
     size: 50Gi
   persistentvolumewdir:
+    existingClaim: panda-shared-logs
+    subPath: harvester-wdirs
     selector: false
     size: 50Gi
   persistentvolumecondor:
@@ -41,7 +43,7 @@ mariadb:
   persistentvolume:
     create: false
     selector: false
-    existingClaim: panda-harvester-wdirs
+    existingClaim: panda-shared-logs
     subPath: mariadb-data
 
   nodeSelector:


### PR DESCRIPTION
## Summary

- Routes `panda-harvester-wdirs` and mariadb storage through the existing `panda-shared-logs` CephFS PVC (subPaths `harvester-wdirs` and `mariadb-data`)
- Avoids provisioning an additional Manila share against the 10-share quota limit of the `ATLAS Services PanDA` OpenStack project
- No new PVC is created; both volumes mount subdirectories of the already-provisioned 200Gi `panda-shared-logs` share

## Test plan

- [ ] ArgoCD syncs without error
- [ ] `panda-harvester-0` and `panda-harvester-mariadb-0` reach `1/1 Running`
- [ ] `kubectl exec panda-harvester-mariadb-0 -- df -h /var/log/harvester_wdirs` shows the shared CephFS mount