### PR TITLE
DOMA: set mariadb fsGroup=1001 for CephFS subPath permissions

### DIFF
--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -40,6 +40,9 @@ harvester:
       memory: 8Gi
 
 mariadb:
+  podSecurityContext:
+    fsGroup: 1001
+
   persistentvolume:
     create: false
     selector: false


### PR DESCRIPTION
## Summary

- Sets `podSecurityContext.fsGroup: 1001` for the DOMA mariadb pod
- The Bitnami MariaDB image runs as uid/gid 1001; without `fsGroup`, the CephFS subPath directory (`mariadb-data` on `panda-shared-logs`) is created root-owned and the process cannot write to it
- Same root cause as the BigMon log permission issue (PR #225), applied to mariadb

## Test plan

- [ ] `panda-harvester-mariadb-0` reaches `1/1 Running`
- [ ] MariaDB initialises successfully (no `Permission denied` in logs)