### PR TITLE
bigmon: fix image tag and pullPolicy for testbed and DOMA

### DIFF
--- a/helm/bigmon/values/values-atlas_testbed.yaml
+++ b/helm/bigmon/values/values-atlas_testbed.yaml
@@ -4,6 +4,10 @@
 #
 
 main:
+  image:
+    tag: "latest"
+    pullPolicy: Always
+
   tolerations:
     - key: "node.kubernetes.io/not-ready"
       operator: "Exists"

--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -4,6 +4,10 @@
 #
 
 main:
+  image:
+    tag: "v1.0.5"
+    pullPolicy: Always
+
   persistentvolume:
     create: false
     sharedPvcName: panda-shared-logs


### PR DESCRIPTION
## Summary

- Default chart tag `master` is not published by the CI (which publishes `latest` and `v{version}` only), so testbed/DOMA were running a very old cached image
- `pullPolicy: IfNotPresent` prevented the kubelet from ever re-pulling a mutable tag
- Testbed: switched to `tag: latest` + `pullPolicy: Always` — picks up new releases on any pod restart
- DOMA: pinned to `tag: v1.0.5` + `pullPolicy: Always` — explicit version, bump tag manually for each release

## Test plan

- [ ] ArgoCD syncs bigmon on testbed → pod restarts and pulls `latest` (v1.0.5)
- [ ] ArgoCD syncs bigmon on DOMA → pod restarts and pulls `v1.0.5`
- [ ] bigpanda-tb.cern.ch shows the new BigMon version