### PR TITLE
Bump panda-server and panda-jedi to 1.0.0

### DIFF
--- a/helm/panda/values.yaml
+++ b/helm/panda/values.yaml
@@ -11,7 +11,7 @@ jedi:
 
   # container image and tag
   image:
-    tag: "0.8.1"
+    tag: "1.0.0"
     # tag: "master"
 
   # PV with selector support
@@ -32,7 +32,7 @@ server:
 
   # container image and tag
   image:
-    tag: "0.8.1"
+    tag: "1.0.0"
     # tag: "master"
 
   # PV with selector support


### PR DESCRIPTION
Bumps both panda-server and panda-jedi image tags from 0.8.1 to 1.0.0 in the default Helm values.

Version 1.0.0 includes the GPU brokerage improvements merged in May 2026: worker node GPU monitoring as primary source for vram, microarchitecture and driver version filters, shorthand gpu_spec syntax, and associated parsing fixes.