### PR TITLE
Auto-deploy latest panda-server and jedi to testbed on every main branch build

### DIFF
--- a/argocd-apps/testbed/panda.yaml
+++ b/argocd-apps/testbed/panda.yaml
@@ -3,6 +3,14 @@ kind: Application
 metadata:
   name: panda
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: server=ghcr.io/pandawms/panda-server:latest,jedi=ghcr.io/pandawms/panda-server:latest
+    argocd-image-updater.argoproj.io/server.update-strategy: digest
+    argocd-image-updater.argoproj.io/server.helm.image-name: server.image.repository
+    argocd-image-updater.argoproj.io/server.helm.image-tag: server.image.tag
+    argocd-image-updater.argoproj.io/jedi.update-strategy: digest
+    argocd-image-updater.argoproj.io/jedi.helm.image-name: jedi.image.repository
+    argocd-image-updater.argoproj.io/jedi.helm.image-tag: jedi.image.tag
 spec:
   project: default
   source:

--- a/helm/panda/values/values-atlas_testbed.yaml
+++ b/helm/panda/values/values-atlas_testbed.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 
 server:
+  image:
+    tag: "latest"
   configFile: panda_server_config.atlas_testbed.json
   tolerations:
     - key: "node.kubernetes.io/not-ready"
@@ -93,6 +95,8 @@ server:
             hostOverride: pandaserver-tb.cern.ch
 
 jedi:
+  image:
+    tag: "latest"
   configFile: panda_jedi_config.atlas_testbed.json
   tolerations:
     - key: "node.kubernetes.io/not-ready"


### PR DESCRIPTION
Configures the atlas testbed to automatically pick up new panda-server and jedi images whenever a build completes on the main branch.

Two changes:
- The testbed values overlay now sets `server.image.tag` and `jedi.image.tag` to `latest`, overriding the version-pinned default in `values.yaml`. Production deployments that use the default values are unaffected.
- The panda ArgoCD Application gains image updater annotations that watch `ghcr.io/pandawms/panda-server:latest` and update both tags via digest tracking when a new image is pushed. This follows the same pattern already used for bigmon on the testbed.

Requires the companion panda-server PR that adds the push-to-main Docker build trigger.