### PR TITLE
Pin bigmon base image to v1.0.16, track latest on atlas testbed only

### DIFF
--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -12,7 +12,7 @@ main:
   enabled: true
 
   image:
-    tag: "latest"
+    tag: "v1.0.16"
 
   autoStart: true
 

--- a/helm/bigmon/values/values-atlas_testbed.yaml
+++ b/helm/bigmon/values/values-atlas_testbed.yaml
@@ -4,6 +4,8 @@
 #
 
 main:
+  image:
+    tag: "latest"
   tolerations:
     - key: "node.kubernetes.io/not-ready"
       operator: "Exists"


### PR DESCRIPTION
The bigmon base values.yaml had tag: "latest" as the default, meaning any deployment without an overlay would track latest automatically. This is inconsistent with how panda-server is set up, where the base is pinned to a specific version and only the testbed overrides to latest.

This change pins the base to v1.0.16 (current latest release) and moves the latest tag into the atlas testbed overlay, matching the pattern used for panda-server.