### PR TITLE
Add panda-msgsvc ArgoCD application to atlas testbed

### DIFF
--- a/argocd-apps/testbed/msgsvc.yaml
+++ b/argocd-apps/testbed/msgsvc.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda-msgsvc
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/msgsvc
+    helm:
+      valueFiles:
+        - values.yaml
+        - values/values-cern.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Adds the `panda-msgsvc` ArgoCD Application manifest for the atlas testbed, mirroring the existing DOMA deployment. Uses `values.yaml` + `values/values-cern.yaml` (conservative resource limits appropriate for testbed).

The previously manually-installed Helm release (`msgsvc`, from 2024-07-31) has been uninstalled and replaced by ArgoCD-managed deployment.