### PR TITLE
Limit iDDS httpd worker count to reduce idle memory on testbed

### DIFF
--- a/helm/idds/charts/rest/templates/configmap.yaml
+++ b/helm/idds/charts/rest/templates/configmap.yaml
@@ -32,6 +32,21 @@ data:
   no_proxy: "localhost,{{ include "rest.fullname" . }},{{ .Release.Name }}-daemon,{{ .Release.Name }}-postgres"
   {{- end}}
   {{- end }}
+  {{- if .Values.serverConf.minWorkers }}
+  IDDS_SERVER_CONF_MIN_WORKERS: "{{ .Values.serverConf.minWorkers }}"
+  {{- end }}
+  {{- if .Values.serverConf.maxWorkers }}
+  IDDS_SERVER_CONF_MAX_WORKERS: "{{ .Values.serverConf.maxWorkers }}"
+  {{- end }}
+  {{- if .Values.serverConf.numWsgi }}
+  IDDS_SERVER_CONF_NUM_WSGI: "{{ .Values.serverConf.numWsgi }}"
+  {{- end }}
+  {{- if .Values.serverConf.numWsgiThread }}
+  IDDS_SERVER_CONF_NUM_WSGI_THREAD: "{{ .Values.serverConf.numWsgiThread }}"
+  {{- end }}
+  {{- if .Values.serverConf.maxBacklog }}
+  IDDS_SERVER_CONF_MAX_BACKLOG: "{{ .Values.serverConf.maxBacklog }}"
+  {{- end }}
 
 
 ---

--- a/helm/idds/charts/rest/values.yaml
+++ b/helm/idds/charts/rest/values.yaml
@@ -150,3 +150,10 @@ cvmfs:
   #   repository: atlas.cern.ch
   # - name: atlas-condb
   #   repository: atlas-condb.cern.ch
+
+serverConf:
+  minWorkers: ""
+  maxWorkers: ""
+  numWsgi: ""
+  numWsgiThread: ""
+  maxBacklog: ""

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -29,6 +29,12 @@ rest:
     class: manual
     selector: true
     size: 10Gi
+  serverConf:
+    minWorkers: "4"
+    maxWorkers: "8"
+    numWsgi: "2"
+    numWsgiThread: "4"
+    maxBacklog: "50"
 
   ingress:
     enabled: true


### PR DESCRIPTION
The `IDDS_SERVER_CONF_MAX_WORKERS` and related variables are referenced in the iDDS httpd config but were never injected as environment variables by the Helm chart. As a result Apache fell back to its defaults and spawned ~35 idle worker processes consuming ~3 GB of RAM on the testbed node (node-5 was sitting at 93% memory with no actual iDDS traffic).

## Changes

- Add a `serverConf` block to `helm/idds/charts/rest/values.yaml` with empty string defaults for all five `IDDS_SERVER_CONF_*` variables
- Wire those values into the env ConfigMap in `configmap.yaml` (only emitted when non-empty, so no impact on existing deployments that don't set them)
- Set lean values in `values-atlas_testbed.yaml`: `MaxRequestWorkers=8`, `MaxSpareThreads=8`, `ServerLimit=8`, 2 WSGI processes × 4 threads

With `ThreadsPerChild=100` and `MaxRequestWorkers=8`, Apache runs a single process instead of ~35, dropping iDDS memory from ~3 GB to ~150 MB on the testbed.

## Test plan

- [ ] ArgoCD syncs the panda-idds app on the atlas testbed without errors
- [ ] `kubectl exec panda-idds-rest-0 -- ps aux | grep httpd | wc -l` returns a small number (1-3) instead of ~35
- [ ] iDDS REST endpoint remains reachable