### PR TITLE
Limit iDDS httpd worker count on DOMA cluster

### DIFF
--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -13,6 +13,12 @@ rest:
     requests:
       cpu: 2000m
       memory: 8Gi
+  serverConf:
+    minWorkers: "4"
+    maxWorkers: "8"
+    numWsgi: "2"
+    numWsgiThread: "4"
+    maxBacklog: "50"
 
   ingress:
     enabled: true


### PR DESCRIPTION
Same fix as #236 applied to the DOMA cluster. The `serverConf` block was missing from `values-doma-k8s.yaml`, so iDDS was running with Apache defaults (~35 idle httpd workers, ~3 GB RAM) on DOMA node-2 which is already at 80% memory.

Sets `MaxRequestWorkers=8` with `ThreadsPerChild=100`, reducing Apache from ~35 processes to ~1 and expected memory from ~3 GB to ~400 MB.