### PR TITLE
Set resource limits for bigmon and right-size iDDS memory limits

### DIFF
--- a/helm/bigmon/values/values-atlas_testbed.yaml
+++ b/helm/bigmon/values/values-atlas_testbed.yaml
@@ -28,6 +28,14 @@ main:
       - name: atlas-condb
         repository: atlas-condb.cern.ch
 
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "4"
+      memory: 6Gi
+
   ingress:
     enabled: true
     hosts:

--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -10,6 +10,14 @@ main:
     subPath: bigmon-logs
     size: 50Gi
 
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "4"
+      memory: 6Gi
+
   ingress:
     enabled: true
     hosts:

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -11,7 +11,7 @@ rest:
       memory: 2Gi
     limits:
       cpu: "4"
-      memory: 6Gi
+      memory: 4Gi
   persistentvolume:
     create: true
     class: manual

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -9,10 +9,10 @@ rest:
   resources:
     limits:
       cpu: 2000m
-      memory: 8Gi
+      memory: 4Gi
     requests:
-      cpu: 2000m
-      memory: 8Gi
+      cpu: 1000m
+      memory: 1Gi
   serverConf:
     minWorkers: "4"
     maxWorkers: "8"


### PR DESCRIPTION
## BigMon — add missing resource limits

Both the atlas testbed and DOMA (values-cern) bigmon deployments had no resource limits configured, leaving nodes unprotected against memory growth. Based on current observed usage (~1.8 Gi), setting:

- CPU: request 1, limit 4
- Memory: request 2 Gi, limit 6 Gi

## iDDS — reduce memory limits

Following the httpd worker count fix (PRs #236/#237), iDDS actual memory usage dropped from ~3 GB to ~330 Mi. The old limits (6 Gi on testbed, 8 Gi on DOMA) were sized for the bloated default config. Reducing to 4 Gi on both clusters, which still gives 10× headroom over current usage. Also corrects the DOMA request from 8 Gi (same as limit, which was over-provisioned) to 1 Gi.