### PR TITLE
Add liveness probes to panda-server and panda-jedi

### DIFF
--- a/helm/panda/charts/jedi/templates/statefulset.yaml
+++ b/helm/panda/charts/jedi/templates/statefulset.yaml
@@ -96,6 +96,23 @@ spec:
             - name: https
               containerPort: 25443
               protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - test
+                - -f
+                - /var/log/panda/panda_jedi_stdout.log
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "test -f /var/run/panda/panda_jedi.pid && kill -0 $(cat /var/run/panda/panda_jedi.pid)"
+            initialDelaySeconds: 120
+            periodSeconds: 60
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/panda/charts/server/templates/statefulset.yaml
+++ b/helm/panda/charts/server/templates/statefulset.yaml
@@ -112,6 +112,12 @@ spec:
                 - /tmp/panda_server_start.log
             initialDelaySeconds: 5
             periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 25080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Problem

Both pods can appear `Running` while the internal processes are dead:

- **panda-server** had a readiness probe (checks startup log) but no liveness probe — if httpd dies after startup, Kubernetes never restarts it
- **panda-jedi** had no probes at all — observed today: JediMaster crashed at startup due to a stomp.py 9.x incompatibility, but the pod sat `Running` for 26+ hours with 0 Python processes

## Changes

**panda-server** — add liveness probe:
- `tcpSocket` on port 25080 (verified responding with 403 on unauthenticated requests, which confirms httpd is alive)
- `initialDelaySeconds: 60`, `periodSeconds: 30`, `failureThreshold: 3`

**panda-jedi** — add readiness + liveness probes:
- Readiness: checks `/var/log/panda/panda_jedi_stdout.log` exists (created at startup)
- Liveness: checks `/var/run/panda/panda_jedi.pid` exists and the process is alive via `kill -0`
- `initialDelaySeconds: 120` for liveness (jedi takes time to start all workers)

Both files verified to exist reliably in the running pod before use.