### PR TITLE
Add liveness probe to bigmon

### DIFF
--- a/helm/bigmon/charts/main/templates/statefulset.yaml
+++ b/helm/bigmon/charts/main/templates/statefulset.yaml
@@ -91,6 +91,12 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Add a `tcpSocket` liveness probe on port 8443 to the bigmon StatefulSet.

Without a liveness probe, a crashed or hung Apache httpd process goes undetected — the pod continues to show `Running` while serving no traffic. Kubernetes will now restart the container automatically if the port stops accepting connections.

The `initialDelaySeconds: 120` accounts for bigmon's startup sequence: config template processing, database readiness wait, and Apache initialisation before the port becomes available.

This follows the same pattern as the liveness probes added to panda-server and panda-jedi in #240.