### PR TITLE
Bump bigmon to v1.1.2 and panda-postgres to 0.1.5-2

### DIFF
--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -12,7 +12,7 @@ main:
   enabled: true
 
   image:
-    tag: "v1.0.16"
+    tag: "v1.1.2"
 
   autoStart: true
 

--- a/helm/panda/values.yaml
+++ b/helm/panda/values.yaml
@@ -94,7 +94,7 @@ postgres:
 
   # container image and tag
   image:
-    tag: "0.1.3"
+    tag: "0.1.5-2"
     #tag: "main"
 
   # PV with selector support


### PR DESCRIPTION
Bring two chart defaults up to the latest released versions.

**bigmon** `v1.0.16` → `v1.1.2`
Picks up three releases from May 2026:
- v1.1.0: panda-authz integration, OIDC token support for BigMon authentication (ATLASPANDA-1757)
- v1.1.1/v1.1.2: dependency conflict fixes

The atlas testbed overrides this with `tag: latest` and has been running v1.1.x already. This update applies to deployments that fall back to the chart default (e.g. DOMA).

**panda-postgres** `0.1.3` → `0.1.5-2`
Picks up panda-database releases 0.1.4 (May 2026: ARCHITECTURE and DRIVER_VERSION columns in MV_WORKER_NODE_GPU_SUMMARY) and 0.1.5/0.1.5-2 (async processing tables, schema bumped to 0.1.5).

panda-server and panda-jedi are both already at the current latest (`1.0.0`) — no change needed.