### PR TITLE
Add liveness probe to iDDS

### DIFF
--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -132,6 +132,12 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            failureThreshold: 3
           envFrom:
             - configMapRef:
                 name: {{ include "rest.fullname" . }}-envs


### PR DESCRIPTION
Add a `tcpSocket` liveness probe on port 8443 to the iDDS StatefulSet.

Without a liveness probe, a crashed or hung httpd process goes undetected — the pod continues to show `Running` while serving no traffic. Kubernetes will now restart the container automatically if the port stops accepting connections.

Port 8443 was verified to be open and accepting connections on the testbed. The `initialDelaySeconds: 120` accounts for the database readiness wait and daemon startup sequence before the port becomes available.

This follows the same pattern as the liveness probes added to panda-server and panda-jedi in #240 and bigmon in #241.