### PR TITLE
Add liveness probe to ActiveMQ (msgsvc)

### DIFF
--- a/helm/msgsvc/charts/activemq/templates/deployment.yaml
+++ b/helm/msgsvc/charts/activemq/templates/deployment.yaml
@@ -86,6 +86,12 @@ spec:
             - name: activemq-port
               containerPort: 61613
               protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 61613
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Add a `tcpSocket` liveness probe on port 61613 to the ActiveMQ Deployment.

Port 61613 is the STOMP port declared in the chart values and used by PanDA components (panda-server, panda-jedi, harvester) for messaging. It was verified to be open and accepting connections on the testbed. The `initialDelaySeconds: 60` accounts for JVM and broker startup.

This completes liveness probe coverage across all PanDA k8s components: panda-server and panda-jedi (#240), bigmon (#241), iDDS (#243), and now ActiveMQ.