### PR TITLE
Add readiness probe to bigmon

### DIFF
--- a/helm/bigmon/charts/main/templates/statefulset.yaml
+++ b/helm/bigmon/charts/main/templates/statefulset.yaml
@@ -91,6 +91,12 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
           livenessProbe:
             tcpSocket:
               port: 8443


### PR DESCRIPTION
Add a `tcpSocket` readiness probe on port 8443 to the bigmon StatefulSet.

The readiness probe prevents the Ingress from routing web traffic to the pod before Apache httpd is ready to accept connections — during initial startup, restarts, or rolling updates. The pod is removed from Service endpoints until the probe passes.

The `initialDelaySeconds: 30` and `periodSeconds: 10` are intentionally shorter than the liveness probe (120s / 30s) to minimise the window where requests would hit an unready pod.

Complements the liveness probe added in #241.