### PR TITLE
Add readiness probe to iDDS

### DIFF
--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -132,6 +132,12 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
           livenessProbe:
             tcpSocket:
               port: 8443


### PR DESCRIPTION
Add a `tcpSocket` readiness probe on port 8443 to the iDDS StatefulSet.

The readiness probe prevents traffic from being routed to the pod before httpd is ready to accept connections — during initial startup, restarts, or rolling updates. The pod is removed from Service endpoints until the probe passes.

Port 8443 was verified open on the testbed. The `initialDelaySeconds: 30` and `periodSeconds: 10` are intentionally shorter than the liveness probe (120s / 30s) to minimise the window where requests would hit an unready pod.

Complements the liveness probe added in #243. Follows the same pattern as the bigmon readiness probe in #245.