### PR TITLE
Add readiness probe to ActiveMQ (msgsvc)

### DIFF
--- a/helm/msgsvc/charts/activemq/templates/deployment.yaml
+++ b/helm/msgsvc/charts/activemq/templates/deployment.yaml
@@ -92,6 +92,12 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 61613
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Adds a readiness probe to the ActiveMQ deployment, matching the same port (61613 STOMP) and parameters used by the existing liveness probe.

This rounds out the probe initiative — all PanDA k8s components now have both liveness and readiness probes.

| Probe | Type | Port | initialDelaySeconds | periodSeconds | failureThreshold |
|---|---|---|---|---|---|
| liveness | tcpSocket | 61613 | 60 | 30 | 3 |
| readiness | tcpSocket | 61613 | 30 | 10 | 3 |

Port 61613 is confirmed as the STOMP connector in `activemq.xml`.