### PR TITLE
Bump iDDS image to 2.6.10 on ATLAS testbed

### DIFF
--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -4,6 +4,8 @@
 
 rest:
   replicaCount: 1
+  image:
+    tag: "2.6.10"
   iddsServer: panda-idds-tb.cern.ch
   resources:
     requests:


### PR DESCRIPTION
Bumps the iDDS server image from 2.2.49 to 2.6.10 on the ATLAS testbed only, leaving other deployments (Rubin/LSST, DOMA) unchanged.

iDDS 2.2.49 is significantly behind the current release. The upgrade is being tested on the testbed first. If successful, the default tag in `values.yaml` can be updated in a follow-up PR to roll out to other deployments.