### PR TITLE
Bump iDDS image to 2.6.11 on ATLAS testbed and DOMA

### DIFF
--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -5,7 +5,7 @@
 rest:
   replicaCount: 1
   image:
-    tag: "2.6.10"
+    tag: "2.6.11"
   iddsServer: panda-idds-tb.cern.ch
   resources:
     requests:

--- a/helm/idds/values/values-cern.yaml
+++ b/helm/idds/values/values-cern.yaml
@@ -4,6 +4,8 @@
 
 rest:
   replicaCount: 2
+  image:
+    tag: "2.6.11"
   iddsServer: panda-idds-doma.cern.ch
 
   ingress:


### PR DESCRIPTION
Bumps the iDDS image from 2.6.10 → 2.6.11 on the ATLAS testbed.

Also explicitly pins the DOMA iDDS image to 2.6.11. Previously `values-cern.yaml` had no image tag override, so DOMA was falling back to the stale chart default (2.2.49).

## Changes
- `values/values-atlas_testbed.yaml`: 2.6.10 → 2.6.11
- `values/values-cern.yaml`: add `image.tag: "2.6.11"` (was unset / falling back to 2.2.49)

Release notes: https://github.com/HSF/iDDS/releases/tag/2.6.11