### PR TITLE
Bump bigmon default image tag from v1.1.2 to v1.1.7

### DIFF
--- a/helm/bigmon/values.yaml
+++ b/helm/bigmon/values.yaml
@@ -12,7 +12,7 @@ main:
   enabled: true
 
   image:
-    tag: "v1.1.2"
+    tag: "v1.1.7"
 
   autoStart: true
 


### PR DESCRIPTION
Bumps the bigmon chart default image tag from v1.1.2 to v1.1.7.

All environments without an explicit tag override (DOMA, LSST, sphenix, dev) were falling back to the stale chart default. This brings them up to date in one change.

The ATLAS testbed is unaffected — it pins `tag: "latest"` explicitly in `values-atlas_testbed.yaml`.

Release notes:
- [v1.1.7](https://github.com/PanDAWMS/panda-bigmon-core/releases/tag/v1.1.7): Fix `__init__` return to base class in cachecontroller
- [v1.1.6](https://github.com/PanDAWMS/panda-bigmon-core/releases/tag/v1.1.6), [v1.1.5](https://github.com/PanDAWMS/panda-bigmon-core/releases/tag/v1.1.5), [v1.1.3](https://github.com/PanDAWMS/panda-bigmon-core/releases/tag/v1.1.3): various bug fixes since v1.1.2