### PR TITLE
Add ArgoCD Application for panda-ui on the ATLAS testbed

### DIFF
--- a/argocd-apps/testbed/ui.yaml
+++ b/argocd-apps/testbed/ui.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: panda-ui
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PanDAWMS/panda-k8s.git
+    targetRevision: main
+    path: helm/ui
+    helm:
+      valueFiles:
+        - values.yaml
+        - values/values-atlas_testbed.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: ""
+      kind: ConfigMap
+      name: panda-ui-backend-sandbox
+      jsonPointers:
+        - /binaryData


### PR DESCRIPTION
This registers the panda-ui chart from #251 as an ArgoCD Application on the ATLAS testbed, following the exact same pattern as bigmon and idds: syncs helm/ui with values.yaml plus values/values-atlas_testbed.yaml, automated prune and self-heal.

The ignoreDifferences entry for the backend sandbox ConfigMap's binaryData is a preemptive fix, not speculative: that ConfigMap bundles a ~280KB base64-encoded tnsnames.ora, close to the same size that caused ArgoCD sync loops on panda-external-sandbox before (see the RespectIgnoreDifferences/binaryData fix already in panda.yaml). No volumeClaimTemplates exception is needed here since the backend uses the shared panda-shared-logs PVC on testbed rather than a StatefulSet-owned volume claim.

This only adds the git-tracked Application manifest. It still needs a one-time kubectl apply -f argocd-apps/testbed/ui.yaml -n argocd against the testbed cluster to actually register it with ArgoCD, since this repo has no app-of-apps auto-discovery.