### PR TITLE
Auto-deploy panda-ui images via ArgoCD image updater

### DIFF
--- a/argocd-apps/testbed/ui.yaml
+++ b/argocd-apps/testbed/ui.yaml
@@ -3,6 +3,14 @@ kind: Application
 metadata:
   name: panda-ui
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: backend=ghcr.io/pandawms/panda-ui-backend:latest,frontend=ghcr.io/pandawms/panda-ui-frontend:latest
+    argocd-image-updater.argoproj.io/backend.update-strategy: digest
+    argocd-image-updater.argoproj.io/backend.helm.image-name: backend.image.repository
+    argocd-image-updater.argoproj.io/backend.helm.image-tag: backend.image.tag
+    argocd-image-updater.argoproj.io/frontend.update-strategy: digest
+    argocd-image-updater.argoproj.io/frontend.helm.image-name: frontend.image.repository
+    argocd-image-updater.argoproj.io/frontend.helm.image-tag: frontend.image.tag
 spec:
   project: default
   source:


### PR DESCRIPTION
The panda-ui backend/frontend images are tagged latest with pullPolicy IfNotPresent, so a running pod never re-pulls a new image on its own once it's already started, even after CI publishes a fix. We just hit this directly: an OAuth login fix landed in the panda-ui backend, but the already-running pod kept serving the old broken code until we noticed and restarted it by hand.

This adds the same argocd-image-updater annotations already used for panda-server and panda-jedi in panda.yaml, tracking the latest tag's digest for both backend and frontend so new images get picked up and redeployed automatically instead of silently going stale.