### PR TITLE
Document bigmon image-updater config and add missing ImageUpdater CRD for panda-ui

### DIFF
--- a/argocd-apps/testbed/bigmon-image-updater.yaml
+++ b/argocd-apps/testbed/bigmon-image-updater.yaml
@@ -1,0 +1,9 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: bigmon-image-updater
+  namespace: argocd
+spec:
+  applicationRefs:
+    - namePattern: panda-bigmon
+      useAnnotations: true

--- a/argocd-apps/testbed/bigmon.yaml
+++ b/argocd-apps/testbed/bigmon.yaml
@@ -3,6 +3,11 @@ kind: Application
 metadata:
   name: panda-bigmon
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: bigmon=ghcr.io/pandawms/panda-bigmon-core:latest
+    argocd-image-updater.argoproj.io/bigmon.update-strategy: digest
+    argocd-image-updater.argoproj.io/bigmon.helm.image-name: main.image.repository
+    argocd-image-updater.argoproj.io/bigmon.helm.image-tag: main.image.tag
 spec:
   project: default
   source:

--- a/argocd-apps/testbed/ui-image-updater.yaml
+++ b/argocd-apps/testbed/ui-image-updater.yaml
@@ -1,0 +1,9 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: panda-ui-image-updater
+  namespace: argocd
+spec:
+  applicationRefs:
+    - namePattern: panda-ui
+      useAnnotations: true


### PR DESCRIPTION
While setting up auto-deploy for panda-ui (#253), we found bigmon has actually been auto-updating via argocd-image-updater since May, confirmed by real update history in its ImageUpdater status (a digest change on 2026-07-10). But neither the Application annotations nor the ImageUpdater CRD object that make this work were ever committed to git; they only exist as live cluster state. A cluster rebuild or a plain kubectl apply of the current bigmon.yaml would silently lose this.

This commits both pieces for bigmon, and adds the equivalent ImageUpdater CRD for panda-ui. This cluster's image-updater runs in operator/CRD mode, which only acts on Applications explicitly referenced by an ImageUpdater's applicationRefs — the annotations added in #253 alone do nothing without this.

panda-server and panda-jedi likely have the same gap (annotations in panda.yaml, no ImageUpdater CRD), but that's intentionally out of scope here.