### PR TITLE
Add missing ImageUpdater CRD for panda-server and panda-jedi

### DIFF
--- a/argocd-apps/testbed/panda-image-updater.yaml
+++ b/argocd-apps/testbed/panda-image-updater.yaml
@@ -1,0 +1,9 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: panda-image-updater
+  namespace: argocd
+spec:
+  applicationRefs:
+    - namePattern: panda
+      useAnnotations: true


### PR DESCRIPTION
Following up on #253 and #254: panda-server and panda-jedi have argocd-image-updater annotations in panda.yaml (server/jedi image tracking by digest), but no ImageUpdater CRD object referencing the panda Application. Since this cluster's image-updater only acts on Applications explicitly enrolled via an ImageUpdater's applicationRefs, those annotations have likely been inert this whole time, same gap already found and fixed for bigmon and panda-ui.

This adds the missing CRD, following the exact same pattern as bigmon-image-updater.yaml and ui-image-updater.yaml.