### PR TITLE
Pin DOMA panda-server/jedi to 1.0.2 and bigmon to v1.1.7

### DIFF
--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -4,6 +4,8 @@
 #
 
 main:
+  image:
+    tag: "v1.1.7"
   persistentvolume:
     create: false
     sharedPvcName: panda-shared-logs

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 
 server:
+  image:
+    tag: "1.0.2"
   # use Route class for ingress
   route:
     enabled: false
@@ -35,6 +37,8 @@ server:
       memory: 8Gi
 
 jedi:
+  image:
+    tag: "1.0.2"
   persistentvolume:
     create: false
     selector: false


### PR DESCRIPTION
panda-server and panda-jedi on DOMA were silently running the parent chart's default of 1.0.0, with no explicit tag override in values-cern.yaml. This pins both to 1.0.2, the latest release.

bigmon on DOMA has actually been floating on latest this whole time via a live-only argocd-image-updater ImageUpdater CRD that was never committed to git (same undocumented drift we found and fixed for the ATLAS testbed in #254). Rather than documenting that CRD the same way, we're pinning bigmon explicitly to v1.1.7 (the version it already resolves to) and removing the live CRD afterward, so DOMA moves to fully version-pinned deployments across the board instead of floating on latest.

IMPORTANT: do not merge until the DOMA postgres schema has been patched to match panda-server 1.0.2. The panda Application has automated sync enabled, so merging this triggers an immediate rollout.