### PR TITLE
Add anti-affinity and fast eviction tolerations to DOMA

### DIFF
--- a/helm/bigmon/values/values-cern.yaml
+++ b/helm/bigmon/values/values-cern.yaml
@@ -6,6 +6,15 @@
 main:
   image:
     tag: "v1.1.7"
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
   persistentvolume:
     create: false
     sharedPvcName: panda-shared-logs

--- a/helm/panda/values/values-cern.yaml
+++ b/helm/panda/values/values-cern.yaml
@@ -5,6 +5,42 @@
 server:
   image:
     tag: "1.0.2"
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: jedi
+            topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: harvester
+            topologyKey: kubernetes.io/hostname
+        - weight: 80
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: main
+            topologyKey: kubernetes.io/hostname
+        - weight: 80
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: rest
+            topologyKey: kubernetes.io/hostname
   # use Route class for ingress
   route:
     enabled: false
@@ -39,6 +75,30 @@ server:
 jedi:
   image:
     tag: "1.0.2"
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: server
+            topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: harvester
+            topologyKey: kubernetes.io/hostname
   persistentvolume:
     create: false
     selector: false


### PR DESCRIPTION
DOMA had no pod anti-affinity or fast-eviction tolerations configured for any component, unlike the ATLAS testbed. This meant panda-server, panda-jedi, harvester, and bigmon could all land on the same physical node with no attempt to spread them, and a NotReady node took Kubernetes' default 300s to evict pods from instead of 30s.

This ports the same rules already used on testbed to panda-server, panda-jedi, and bigmon:

- podAntiAffinity (preferred) spreading server/jedi/harvester/bigmon/idds-rest apart from each other, matching testbed's exact weights.
- tolerations on node.kubernetes.io/not-ready and node.kubernetes.io/unreachable with tolerationSeconds: 30.

harvester is intentionally left out: unlike testbed, DOMA's harvester (and its mariadb) is hard-pinned to a specific node via nodeSelector, tied to a local manual-class PV. Anti-affinity and fast eviction would have no effect there since it has no alternative node to schedule to.

The nodeAffinity rule preferring m4.large instance types (used on testbed) was also left out, since all DOMA nodes are uniform m2.xlarge.