### PR TITLE
Free DOMA harvester and mariadb from their node-3 lock

### DIFF
--- a/helm/harvester/values/values-cern.yaml
+++ b/helm/harvester/values/values-cern.yaml
@@ -15,19 +15,46 @@ harvester:
     selector: false
     size: 50Gi
   persistentvolumecondor:
-    create: true
-    class: manual
-    path: "/mnt/harvester-logs"
+    create: false
+    existingClaim: panda-shared-logs
+    subPath: condor_logs
     selector: false
-    size: 5Gi
   sharedLogs:
     create: true
     name: panda-shared-logs
     size: 200Gi
     storageClass: manila-meyrin-cephfs
 
-  nodeSelector:
-    kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: server
+            topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: jedi
+            topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: rest
+            topologyKey: kubernetes.io/hostname
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 30
 
   resources:
     requests:
@@ -46,9 +73,6 @@ mariadb:
     selector: false
     existingClaim: panda-shared-logs
     subPath: mariadb-data
-
-  nodeSelector:
-    kubernetes.io/hostname: panda-doma-k8s-3bv7ya4fx76z-node-3
 
   resources:
     requests:


### PR DESCRIPTION
Follow-up to #257: DOMA's harvester was hard-pinned to node-3 via nodeSelector because its condor logs lived on a manually-provisioned local hostPath PV that only exists on that one node. mariadb carried the same nodeSelector even though its storage was already on the shared panda-shared-logs PVC, with no actual node dependency.

This switches harvester's condor logs to a subPath on the same shared CephFS-backed panda-shared-logs PVC (matching testbed's pattern exactly), removes both nodeSelectors, and adds the podAntiAffinity/tolerations from #257 to harvester now that it can actually benefit from them.

Confirmed the condor_logs PV is empty (DOMA has no active jobs/tasks right now), so no data migration was needed. Will clean up the now-orphaned panda-harvester-condor-logs PV/PVC on the live cluster separately once this is confirmed deployed and working.