### PR TITLE
Reuse the shared volume for harvester condor logs instead of a duplicate PVC reference

### DIFF
--- a/helm/harvester/charts/harvester/templates/statefulset.yaml
+++ b/helm/harvester/charts/harvester/templates/statefulset.yaml
@@ -305,11 +305,19 @@ spec:
               {{- if .Values.persistentvolumewdir.subPath }}
               subPath: {{ .Values.persistentvolumewdir.subPath }}
               {{- end }}
+            {{- if and .Values.persistentvolumecondor.existingClaim (eq .Values.persistentvolumecondor.existingClaim .Values.persistentvolume.existingClaim) }}
+            - name: {{ include "harvester.fullname" . }}-logs
+              mountPath: /var/log/condor_logs/
+              {{- if .Values.persistentvolumecondor.subPath }}
+              subPath: {{ .Values.persistentvolumecondor.subPath }}
+              {{- end }}
+            {{- else }}
             - name: {{ include "harvester.fullname" . }}-condor-logs
               mountPath: /var/log/condor_logs/
               {{- if .Values.persistentvolumecondor.subPath }}
               subPath: {{ .Values.persistentvolumecondor.subPath }}
               {{- end }}
+            {{- end }}
             - name: {{ include "harvester.fullname" . }}-configjson
               mountPath: /opt/harvester/etc/configmap
             - name: {{ include "harvester.fullname" . }}-queueconfig
@@ -371,9 +379,11 @@ spec:
         - name: {{ include "harvester.fullname" . }}-auth
           secret:
               secretName: {{ .Values.global.secret }}-harvester-auth
+        {{- if not (and .Values.persistentvolumecondor.existingClaim (eq .Values.persistentvolumecondor.existingClaim .Values.persistentvolume.existingClaim)) }}
         - name: {{ include "harvester.fullname" . }}-condor-logs
           persistentVolumeClaim:
             claimName: {{ .Values.persistentvolumecondor.existingClaim | default (printf "%s-condor-logs" (include "harvester.fullname" .)) }}
+        {{- end }}
         {{- if .Values.persistentvolumespecial.mount }}
         - name: {{ include "harvester.fullname" . }}-special-data
           persistentVolumeClaim:


### PR DESCRIPTION
DOMA's harvester references panda-shared-logs for both persistentvolume (harvester-logs) and persistentvolumecondor (condor_logs) — two separate spec.volumes[] entries for the identical underlying PVC. A fresh pod on DOMA (kubelet v1.29.2, node just freed from a hard node-3 lock in #258) got stuck indefinitely in ContainerCreating trying to mount the second reference, with kubelet repeatedly logging:

unmounted volumes=[panda-harvester-condor-logs]: context deadline exceeded

Ruled out before landing on this fix: node health, the Manila backend/share/quota (confirmed healthy and active via openstack share show/access list), CSI driver version (identical v1.28.1 to testbed's working setup), and a stuck driver-side lock (restarting the CSI nodeplugin pod didn't help). testbed's harvester has been running continuously for 81 days on kubelet v1.30.1, so it never needed to freshly establish this exact dual-reference pattern — suspect a kubelet volume-manager issue in 1.29.x around mounting the same PVC twice in one pod, fixed by 1.30, but haven't pinned an exact upstream issue.

Rather than chase the kubelet bug further, this sidesteps it: when persistentvolumecondor.existingClaim matches persistentvolume.existingClaim, condor logs now mount via a second volumeMount (different subPath) on the existing harvester-logs volume, instead of a second volumes[] entry for the same PVC.

testbed is unaffected — its persistentvolume uses a separate dedicated PVC via volumeClaimTemplates (no existingClaim), so the two existingClaims never match there and it keeps its current two-volume setup. Confirmed byte-for-byte identical rendered output for testbed before and after this change.