### PR TITLE
Set Recreate rollout strategy for storage-backed singleton Deployments

### DIFF
--- a/helm/iam/charts/mariadb/templates/deployment.yaml
+++ b/helm/iam/charts/mariadb/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "mariadb.selectorLabels" . | nindent 6 }}

--- a/helm/idds/charts/postgres/templates/deployment.yaml
+++ b/helm/idds/charts/postgres/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "postgres.selectorLabels" . | nindent 6 }}

--- a/helm/msgsvc/charts/activemq/templates/deployment.yaml
+++ b/helm/msgsvc/charts/activemq/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "activemq.selectorLabels" . | nindent 6 }}

--- a/helm/panda/charts/postgres/templates/deployment.yaml
+++ b/helm/panda/charts/postgres/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "postgres.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Follow-up to the DOMA msgsvc-activemq 13-day crash loop diagnosed yesterday. Root cause was the default RollingUpdate strategy (maxSurge 25%): on any rollout, Kubernetes brings up the new pod before killing the old one. For a single-replica broker with a persistent volume, that means two pods briefly both try to open the same exclusive KahaDB lock file — whichever loses the race sits in a restart loop forever waiting on the lock, exactly what we saw.

This isn't specific to activemq. Four charts in this repo are single-replica Deployments writing to a persistent volume with the same default rolling-update behavior:

- msgsvc/activemq
- panda/postgres (enabled by default, live on sphenix)
- idds/postgres (enabled by default, live on sphenix)
- iam/mariadb (defaults to disabled everywhere in this repo's tracked values, not currently live anywhere, fixed anyway for consistency)

Adding `strategy: type: Recreate` to each makes Kubernetes tear down the old pod before creating the new one, so any future chart bump, image update, or values change won't reproduce the same failure mode.

Verified all four render correctly (panda-postgres and idds-postgres rendered with their live sphenix values; activemq with cern values; mariadb with `--set mariadb.enabled=true` since no tracked values file currently turns it on).