### PR TITLE
Bump idds-rest memory request/limit on both clusters

### DIFF
--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -10,10 +10,10 @@ rest:
   resources:
     requests:
       cpu: "1"
-      memory: 2Gi
+      memory: 3Gi
     limits:
       cpu: "4"
-      memory: 4Gi
+      memory: 6Gi
   persistentvolume:
     create: true
     class: manual

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -11,10 +11,10 @@ rest:
   resources:
     limits:
       cpu: 2000m
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 1000m
-      memory: 1Gi
+      memory: 2Gi
   serverConf:
     minWorkers: "4"
     maxWorkers: "8"


### PR DESCRIPTION
panda-idds-rest-0 on the ATLAS testbed was OOMKilled on 2026-07-24, hitting its 4Gi memory limit. Checking DOMA's idds-rest right now, it's running at 3812Mi/4Gi (93%) with the same limit, so it is close to the same failure.

Raised the limit to 6Gi on both testbed and DOMA, with a proportional bump to the memory request so scheduling reflects real usage instead of the previous 2Gi/1Gi requests, which were well below what idds-rest actually consumes in practice.

Checked node headroom before sizing this so the new values don't crowd out other pods:
- testbed node-0 (hosts idds-rest): ~6.75Gi allocatable, current requests only ~40% of that
- DOMA node-0 (hosts bigmon, harvester, idds-rest): ~14.2Gi allocatable, current requests only ~36% of that

Both have comfortable room for the increase.