### PR TITLE
Fix msgsvc/idds/bigmon/harvester secrets refs to derive from panda_ref

### DIFF
--- a/secrets/templates/_helpers.tpl
+++ b/secrets/templates/_helpers.tpl
@@ -81,24 +81,31 @@ Add affix to instance reference names
 {{- include "add_affix" (list .Values.affix "iam") }}
 {{- end }}
 
-{{- define "msgsvc_ref" }}
-{{- include "add_affix" (list .Values.affix "msgsvc") }}
-{{- end }}
-
 {{- define "panda_ref" }}
 {{- include "add_affix" (list .Values.affix "panda") }}
 {{- end }}
 
+{{/*
+msgsvc, idds, bigmon, and harvester are each deployed as their own ArgoCD Application
+named "panda-<component>" (e.g. "panda-msgsvc"), unlike the panda-server/jedi Application,
+which is simply named "panda". So these refs derive from panda_ref plus their own component
+name, rather than affixing the component name directly - otherwise they render one "panda-"
+short of the real Service names (e.g. "msgsvc-activemq" instead of "panda-msgsvc-activemq").
+*/}}
+{{- define "msgsvc_ref" }}
+{{- include "panda_ref" . }}-msgsvc
+{{- end }}
+
 {{- define "idds_ref" }}
-{{- include "add_affix" (list .Values.affix "idds") }}
+{{- include "panda_ref" . }}-idds
 {{- end }}
 
 {{- define "harvester_ref" }}
-{{- include "add_affix" (list .Values.affix "harvester") }}
+{{- include "panda_ref" . }}-harvester
 {{- end }}
 
 {{- define "bigmon_ref" }}
-{{- include "add_affix" (list .Values.affix "bigmon") }}
+{{- include "panda_ref" . }}-bigmon
 {{- end }}
 
 {{- define "ui_ref" }}


### PR DESCRIPTION
Root cause of an active problem on the ATLAS testbed: idds-rest's Conductor and Receiver messaging agents were stuck in an unthrottled retry loop trying to resolve a broker hostname that doesn't exist, pinning a full CPU core and writing multiple GB/day of error logs (also the actual driver behind idds-rest's recent OOM, since #261 was only a capacity band-aid for this).

msgsvc_ref, idds_ref, bigmon_ref, and harvester_ref each computed add_affix(affix, name) directly. With the empty affix used on both clusters, this rendered as msgsvc/idds/bigmon/harvester with no prefix — one panda- short of the real Service names (panda-msgsvc-activemq, panda-idds-rest, panda-bigmon-main, panda-harvester), because each of those is its own ArgoCD Application literally named panda-<component>, unlike the panda-server/jedi Application, which is simply named panda.

DOMA has the identical bug in its current secrets template, currently masked only because panda-secrets there hasn't been redeployed since before this code path existed — the next redeploy for any unrelated reason would trigger the same problem there too.

Rather than hardcoding a literal "panda-" prefix (which could be wrong for environments outside testbed/DOMA that this repo doesn't have visibility into), these four refs now derive from panda_ref plus their own component name, so they're still driven by the same affix value as before, just composed to match how these Applications are actually named.

Verified by rendering the chart against both clusters' real values-secret.yaml: IDDS_CONDUCTOR_BROKERS/IDDS_RECEIVER_BROKERS/IDDS_HOST/PANDA_IDDS_HOST/HARVESTER_DB_HOST/PANDA_MONITOR_URL/PANDA_ACTIVEMQ_LIST all now resolve to the real Service names on both clusters, while panda_ref-based values (PANDA_URL, PANDA_DB_HOST, etc.) are unchanged.