### PR TITLE
Add a chain.pem fallback to init-panda

### DIFF
--- a/helm/panda/charts/server/sandbox/init-panda
+++ b/helm/panda/charts/server/sandbox/init-panda
@@ -13,6 +13,16 @@ else
     ln -fs /opt/panda/config/hostkey.pem /etc/grid-security/hostkey.pem
 fi
 
+# fall back to self-referencing the host certificate as its own chain when no
+# chain.pem is mounted, so httpd does not fail to start on a dangling
+# /etc/grid-security/chain.pem symlink (baked in by the Dockerfile to point at
+# /opt/panda/etc/cert/chain.pem) whenever the certs secret only provides a host
+# certificate, e.g. via the self-signed fallback above.
+if [ ! -f /opt/panda/etc/cert/chain.pem ]; then
+    unlink /etc/grid-security/chain.pem
+    ln -fs /etc/grid-security/hostcert.pem /etc/grid-security/chain.pem
+fi
+
 # copy idds conf
 mkdir -p /home/atlpan/.idds
 cp /data/panda/idds.cfg /home/atlpan/.idds/idds_local.cfg


### PR DESCRIPTION
init-panda already falls back to a self-signed certificate for hostcert.pem/hostkey.pem when no real one is mounted, but chain.pem has no fallback at all — its symlink is baked into the Dockerfile at build time, pointing unconditionally at /opt/panda/etc/cert/chain.pem. If the panda-certs secret ever provides a host certificate but no chain.pem, that symlink stays dangling and httpd refuses to start with "SSLCertificateChainFile: file does not exist or is empty".

Found this gap while root-causing a real crash-loop on idds-rest, where an empty certs secret left chain.pem dangling with no recovery path at all (fixed for idds in #561 upstream in HSF/iDDS, and #262 in this repo for the underlying secrets ref bug). panda-server's certs secret is currently populated correctly on both clusters, so this isn't an active issue today, but it's a latent gap: if that secret were ever accidentally emptied, panda-server would have strictly less resilience than idds will have once its fix lands.

This closes the same gap for panda-server by falling back to the host certificate itself as the chain when no chain.pem is mounted.