### PR TITLE
Bump iDDS image to 2.6.13 on ATLAS testbed and DOMA

### DIFF
--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -5,7 +5,7 @@
 rest:
   replicaCount: 1
   image:
-    tag: "2.6.11"
+    tag: "2.6.13"
   iddsServer: panda-idds-tb.cern.ch
   resources:
     requests:

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -5,7 +5,7 @@
 rest:
   replicaCount: 1
   image:
-    tag: "2.6.11"
+    tag: "2.6.13"
   iddsServer: panda-idds-doma.cern.ch
 
   resources:


### PR DESCRIPTION
2.6.13 includes both fixes we found while root-causing idds-rest's crash loop this week:

* Fix chain.pem fallback ordering in start-daemon.sh (HSF/iDDS#561)
* Activate Oracle thick mode in the alembic migration engine (HSF/iDDS#560)

Both merged and released upstream on 2026-07-28.