### PR TITLE
Move idds-rest logs onto the shared CephFS logs volume

### DIFF
--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -161,6 +161,9 @@ spec:
           volumeMounts:
               - name: {{ include "rest.fullname" . }}-logs
                 mountPath: /var/log/idds/
+                {{- if .Values.persistentvolume.subPath }}
+                subPath: {{ .Values.persistentvolume.subPath }}
+                {{- end }}
               - name: {{ include "rest.fullname" . }}-configmap
                 mountPath: /opt/idds/configmap
               - name: {{ include "rest.fullname" . }}-certs
@@ -213,6 +216,10 @@ spec:
         - name: {{ include "rest.fullname" . }}-logs
           persistentVolumeClaim:
             claimName: {{ include "rest.fullname" . }}
+  {{- else if .Values.persistentvolume.sharedPvcName }}
+        - name: {{ include "rest.fullname" . }}-logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistentvolume.sharedPvcName }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -15,10 +15,9 @@ rest:
       cpu: "4"
       memory: 6Gi
   persistentvolume:
-    create: true
-    class: manual
-    selector: true
-    size: 5Gi
+    create: false
+    sharedPvcName: panda-shared-logs
+    subPath: idds
   cvmfs:
     enabled: true
     repositories:

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -8,6 +8,10 @@ rest:
     tag: "2.6.13"
   iddsServer: panda-idds-doma.cern.ch
 
+  persistentvolume:
+    create: false
+    sharedPvcName: panda-shared-logs
+    subPath: idds
   resources:
     limits:
       cpu: 2000m


### PR DESCRIPTION
idds-rest's log volume is a hostPath-backed PV on local node disk, declared as 5Gi but not actually enforced by Kubernetes since hostPath doesn't carry real capacity limits. It reached 90% of the node's local disk on testbed and 70% on DOMA (checked while investigating elevated CPU/log volume on idds-rest, driven partly by a currently-open schema issue causing one agent to log heavily until the next image bump resolves it).

This adds sharedPvcName/subPath support to the rest chart, mirroring the exact same pattern panda-server, bigmon, and panda-ui already use for panda-shared-logs, and points both clusters' idds-rest logs at that existing CephFS share (200Gi, under 10% used on both clusters) under its own `idds` subfolder instead of local node disk.

Verified via `helm template` against both clusters' real values files, matching ArgoCD's actual release name (`panda-idds`) rather than the stale/unrelated `idds` Helm release still lingering in each cluster's release history — confirmed the rendered manifest mounts `panda-shared-logs` with `subPath: idds` and no longer creates a dedicated hostPath PV/PVC for logs.

Since `panda-idds`'s ArgoCD Application auto-syncs on merge to main, merging this will restart both clusters' idds-rest pods to pick up the new volume. The old local hostPath log data becomes orphaned on each node afterward (not deleted automatically) — low-priority manual cleanup, not urgent.