### PR TITLE
Move idds-rest requests volume onto the shared CephFS logs volume

### DIFF
--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
 ---
 {{- end }}
 # pv for idds requests
+{{- if not .Values.persistentvolumerequests.sharedPvcName }}
 {{- if .Values.persistentvolumerequests.create -}}
 # pv
 kind: PersistentVolume
@@ -77,6 +78,7 @@ spec:
       {{- include "rest.selectorLabels-requests" . | nindent 6 }}
   {{- end }}
 ---
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -170,6 +172,9 @@ spec:
                 mountPath: /opt/idds/certs
               - name: {{ include "rest.fullname" . }}-requests
                 mountPath: {{ .Values.persistentvolumerequests.path }}
+                {{- if .Values.persistentvolumerequests.subPath }}
+                subPath: {{ .Values.persistentvolumerequests.subPath }}
+                {{- end }}
               {{- if .Values.cvmfs.enabled }}
               {{- range .Values.cvmfs.repositories }}
               - name: cvmfs-{{ .name }}
@@ -203,7 +208,7 @@ spec:
               secretName: {{ .Values.global.secret }}-idds-certs
         - name: {{ include "rest.fullname" . }}-requests
           persistentVolumeClaim:
-              claimName: {{ include "rest.fullname" . }}-requests
+              claimName: {{ if .Values.persistentvolumerequests.sharedPvcName }}{{ .Values.persistentvolumerequests.sharedPvcName }}{{ else }}{{ include "rest.fullname" . }}-requests{{ end }}
         {{- if .Values.cvmfs.enabled }}
         {{- range .Values.cvmfs.repositories }}
         - name: cvmfs-{{ .name }}

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -26,10 +26,9 @@ rest:
       - name: atlas-condb
         repository: atlas-condb.cern.ch
   persistentvolumerequests:
-    create: true
-    class: manual
-    selector: true
-    size: 10Gi
+    create: false
+    sharedPvcName: panda-shared-logs
+    subPath: idds-requests
   serverConf:
     minWorkers: "4"
     maxWorkers: "8"

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -12,6 +12,10 @@ rest:
     create: false
     sharedPvcName: panda-shared-logs
     subPath: idds
+  persistentvolumerequests:
+    create: false
+    sharedPvcName: panda-shared-logs
+    subPath: idds-requests
   resources:
     limits:
       cpu: 2000m


### PR DESCRIPTION
Same underlying issue as #265, on the sibling requests volume: idds-rest-requests is a manual storage-class PV on local node disk, declared 10Gi but with no real capacity enforcement. It's currently empty and unused on both clusters, so this isn't an active problem, but it's the same gap.

Extends the sharedPvcName/subPath support added for the logs volume in #265 to persistentvolumerequests too, mounting it under its own idds-requests subfolder of the existing panda-shared-logs CephFS share (200Gi, well under 10% used on both clusters).

Verified via helm template against both clusters' real values files, matching ArgoCD's actual release name (panda-idds): confirms panda-idds-rest-requests mounts panda-shared-logs with subPath idds-requests, and no dedicated PV/PVC is created for it anymore.