### PR TITLE
Revert idds-rest requests volume onto shared CephFS (breaks pod startup)

### DIFF
--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -38,7 +38,6 @@ spec:
 ---
 {{- end }}
 # pv for idds requests
-{{- if not .Values.persistentvolumerequests.sharedPvcName }}
 {{- if .Values.persistentvolumerequests.create -}}
 # pv
 kind: PersistentVolume
@@ -78,7 +77,6 @@ spec:
       {{- include "rest.selectorLabels-requests" . | nindent 6 }}
   {{- end }}
 ---
-{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -172,9 +170,6 @@ spec:
                 mountPath: /opt/idds/certs
               - name: {{ include "rest.fullname" . }}-requests
                 mountPath: {{ .Values.persistentvolumerequests.path }}
-                {{- if .Values.persistentvolumerequests.subPath }}
-                subPath: {{ .Values.persistentvolumerequests.subPath }}
-                {{- end }}
               {{- if .Values.cvmfs.enabled }}
               {{- range .Values.cvmfs.repositories }}
               - name: cvmfs-{{ .name }}
@@ -208,7 +203,7 @@ spec:
               secretName: {{ .Values.global.secret }}-idds-certs
         - name: {{ include "rest.fullname" . }}-requests
           persistentVolumeClaim:
-              claimName: {{ if .Values.persistentvolumerequests.sharedPvcName }}{{ .Values.persistentvolumerequests.sharedPvcName }}{{ else }}{{ include "rest.fullname" . }}-requests{{ end }}
+              claimName: {{ include "rest.fullname" . }}-requests
         {{- if .Values.cvmfs.enabled }}
         {{- range .Values.cvmfs.repositories }}
         - name: cvmfs-{{ .name }}

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -26,9 +26,10 @@ rest:
       - name: atlas-condb
         repository: atlas-condb.cern.ch
   persistentvolumerequests:
-    create: false
-    sharedPvcName: panda-shared-logs
-    subPath: idds-requests
+    create: true
+    class: manual
+    selector: true
+    size: 10Gi
   serverConf:
     minWorkers: "4"
     maxWorkers: "8"

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -12,10 +12,6 @@ rest:
     create: false
     sharedPvcName: panda-shared-logs
     subPath: idds
-  persistentvolumerequests:
-    create: false
-    sharedPvcName: panda-shared-logs
-    subPath: idds-requests
   resources:
     limits:
       cpu: 2000m


### PR DESCRIPTION
Reverts #266. Both clusters' idds-rest pods are stuck in ContainerCreating for 8+ minutes after this merged — CSI logs show the shared panda-shared-logs volume's initial NodeStageVolume succeeded, but there's no sign of the per-container NodePublishVolume (with subPath) completing for either volume entry since. Referencing the same PVC twice within one pod (logs + requests, each with a different subPath) appears to hit a contention/locking issue in this CephFS-fuse CSI driver that the earlier logs-only change (#265) didn't hit, since that only referenced the shared claim once.

This is an active incident on both clusters right now (idds-rest down), so reverting to restore service. The requests volume goes back to its own dedicated local hostPath PV for now — same known low-priority gap as before, not urgent since it's empty and unused, but worth revisiting with a different approach (e.g. a genuinely separate CephFS share) rather than reusing the same PVC twice in one pod.