### PR TITLE
Move idds-rest requests volume onto the shared logs volume via a second mount

### DIFF
--- a/helm/idds/charts/rest/templates/statefulset.yaml
+++ b/helm/idds/charts/rest/templates/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
 ---
 {{- end }}
 # pv for idds requests
+{{- if not .Values.persistentvolumerequests.reuseLogsVolume }}
 {{- if .Values.persistentvolumerequests.create -}}
 # pv
 kind: PersistentVolume
@@ -77,6 +78,7 @@ spec:
       {{- include "rest.selectorLabels-requests" . | nindent 6 }}
   {{- end }}
 ---
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -168,8 +170,16 @@ spec:
                 mountPath: /opt/idds/configmap
               - name: {{ include "rest.fullname" . }}-certs
                 mountPath: /opt/idds/certs
+              {{- if .Values.persistentvolumerequests.reuseLogsVolume }}
+              - name: {{ include "rest.fullname" . }}-logs
+                mountPath: {{ .Values.persistentvolumerequests.path }}
+                {{- if .Values.persistentvolumerequests.subPath }}
+                subPath: {{ .Values.persistentvolumerequests.subPath }}
+                {{- end }}
+              {{- else }}
               - name: {{ include "rest.fullname" . }}-requests
                 mountPath: {{ .Values.persistentvolumerequests.path }}
+              {{- end }}
               {{- if .Values.cvmfs.enabled }}
               {{- range .Values.cvmfs.repositories }}
               - name: cvmfs-{{ .name }}
@@ -201,9 +211,11 @@ spec:
         - name: {{ include "rest.fullname" . }}-certs
           secret:
               secretName: {{ .Values.global.secret }}-idds-certs
+        {{- if not .Values.persistentvolumerequests.reuseLogsVolume }}
         - name: {{ include "rest.fullname" . }}-requests
           persistentVolumeClaim:
               claimName: {{ include "rest.fullname" . }}-requests
+        {{- end }}
         {{- if .Values.cvmfs.enabled }}
         {{- range .Values.cvmfs.repositories }}
         - name: cvmfs-{{ .name }}

--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -26,10 +26,8 @@ rest:
       - name: atlas-condb
         repository: atlas-condb.cern.ch
   persistentvolumerequests:
-    create: true
-    class: manual
-    selector: true
-    size: 10Gi
+    reuseLogsVolume: true
+    subPath: idds-requests
   serverConf:
     minWorkers: "4"
     maxWorkers: "8"

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -12,6 +12,9 @@ rest:
     create: false
     sharedPvcName: panda-shared-logs
     subPath: idds
+  persistentvolumerequests:
+    reuseLogsVolume: true
+    subPath: idds-requests
   resources:
     limits:
       cpu: 2000m


### PR DESCRIPTION
Second attempt at what #266 tried to do (reverted in #267 after it broke pod startup on both clusters).

#266 declared a second, separately-named volume entry for the requests path that also referenced panda-shared-logs — from kubelet's perspective that's two distinct volumes needing two separate CSI mount operations against the same underlying PVC, which the CephFS-fuse CSI driver in use here doesn't handle well (NodeStageVolume completed but NodePublishVolume never did, both clusters stuck in ContainerCreating indefinitely).

This does it the standard Kubernetes way instead: a `reuseLogsVolume` option that, when set, mounts the requests path via a *second `volumeMounts` entry referencing the already-declared logs volume* (same volume name, different mountPath/subPath), rather than declaring a second volume. kubelet only ever stages `panda-shared-logs` once and does a local bind-mount for the second path — no second CSI operation involved.

Verified via `helm template` against both clusters' real values (matching ArgoCD's actual release name `panda-idds`): only one `claimName: panda-shared-logs` reference exists in the rendered volumes list on either cluster, with two `volumeMounts` entries (both named `panda-idds-rest-logs`) pointing at it — one for `/var/log/idds` (subPath `idds`), one for `/mnt/idds-rest-requests` (subPath `idds-requests`).