### PR TITLE
Fix shared_volume_usage_check to actually check the shared volume

### DIFF
--- a/helm/harvester/charts/harvester/sandbox/health_monitor.py
+++ b/helm/harvester/charts/harvester/sandbox/health_monitor.py
@@ -99,11 +99,15 @@ def condor_q_availability():
     return process_avail
 
 
-def shared_volume_usage_check(path="/var/log/panda", warn_threshold_pct=80):
-    # /var/log/panda is the panda-shared-logs CephFS volume, shared across
-    # panda-server, jedi, bigmon, panda-ui, and idds-rest - a bug in any one
-    # of them filling it up affects all the others too, so it's worth an
-    # early warning here rather than only discovering it during an incident.
+def shared_volume_usage_check(path="/var/log/condor_logs", warn_threshold_pct=80):
+    # /var/log/condor_logs is harvester's mount of the panda-shared-logs
+    # CephFS volume, shared across panda-server, jedi, bigmon, panda-ui, and
+    # idds-rest - a bug in any one of them filling it up affects all the
+    # others too, so it's worth an early warning here rather than only
+    # discovering it during an incident. Note: /var/log/panda is NOT this
+    # volume on every cluster - on testbed it's harvester's own separate
+    # dedicated 50Gi volume, not the 200Gi shared one, so don't switch back
+    # to checking that path.
     try:
         usage = shutil.disk_usage(path)
         used_pct = 100 * usage.used / usage.total


### PR DESCRIPTION
Deployed #269 and checked it was actually logging (per Eddie's request) - it was, but checking the wrong path. /var/log/panda is not reliably the panda-shared-logs volume across clusters: on testbed it's harvester's own separate dedicated 50Gi volume (confirmed via df), so the check logged "1G / 50G" there instead of the actual shared volume's usage. DOMA happened to report 200G total for the same path, likely coincidental given its /var/log/panda isn't even a distinct mount point there.

/var/log/condor_logs is harvester's mount of the actual shared volume and reports 200G total consistently on both clusters. Switches the check to that path.