### PR TITLE
Set an explicit mail sender in the vomsproxy-renew warning scripts

### DIFF
--- a/helm/harvester/charts/harvester/sandbox/doma.vomsproxy-renew
+++ b/helm/harvester/charts/harvester/sandbox/doma.vomsproxy-renew
@@ -29,5 +29,5 @@ voms-proxy-fake -rfc -voms eic -out /data/harvester/run/x509up_u25606 -hours 96 
 voms-proxy-info2 -exists -hours 11 -file $proxy
 
 if [ $? -ne 0 ]; then
-  echo $proxy expires in 11 hours on `hostname`, Please check| mail -s "[VOMS_PROXY]WARNING : Grid proxy for Rubin k8s expires soon on `hostname`" atlas-adc-idds-k8s@cern.ch
+  echo $proxy expires in 11 hours on `hostname`, Please check| mail -r "atlas-adc-panda-no-reply@cern.ch" -s "[VOMS_PROXY]WARNING : Grid proxy for Rubin k8s expires soon on `hostname`" atlas-adc-idds-k8s@cern.ch
 fi

--- a/helm/harvester/charts/harvester/sandbox/lsst.vomsproxy-renew
+++ b/helm/harvester/charts/harvester/sandbox/lsst.vomsproxy-renew
@@ -22,5 +22,5 @@ voms-proxy-init3 -valid 96:00 -rfc -voms lsst:/lsst/Role=drp -q -cert $new_proxy
 voms-proxy-info3 -exists -hours 11 -file $proxy
 
 if [ $? -ne 0 ]; then
-  echo $proxy expires in 11 hours on `hostname`, Please check| mail -s "[VOMS_PROXY]WARNING : Grid proxy for Rubin k8s expires soon on `hostname`" atlas-adc-idds-k8s@cern.ch
+  echo $proxy expires in 11 hours on `hostname`, Please check| mail -r "atlas-adc-panda-no-reply@cern.ch" -s "[VOMS_PROXY]WARNING : Grid proxy for Rubin k8s expires soon on `hostname`" atlas-adc-idds-k8s@cern.ch
 fi

--- a/helm/harvester/charts/harvester/sandbox/lsst_prod.vomsproxy-renew
+++ b/helm/harvester/charts/harvester/sandbox/lsst_prod.vomsproxy-renew
@@ -22,5 +22,5 @@ voms-proxy-init3 -valid 96:00 -rfc -voms lsst:/lsst/Role=drp -q -cert $new_proxy
 voms-proxy-info3 -exists -hours 11 -file $proxy
 
 if [ $? -ne 0 ]; then
-  echo $proxy expires in 11 hours on `hostname`, Please check| mail -s "[VOMS_PROXY]WARNING : Grid proxy for Rubin k8s expires soon on `hostname`" atlas-adc-idds-k8s@cern.ch
+  echo $proxy expires in 11 hours on `hostname`, Please check| mail -r "atlas-adc-panda-no-reply@cern.ch" -s "[VOMS_PROXY]WARNING : Grid proxy for Rubin k8s expires soon on `hostname`" atlas-adc-idds-k8s@cern.ch
 fi


### PR DESCRIPTION
These scripts already pipe a warning through `mail -s ...` when a grid proxy is about to expire, but never set a sender. Found while working on the shared-volume disk alert (#271) that `cernmx.cern.ch` bounces mail from an arbitrary/unauthorized sender by policy — tested directly. Since `mail` was never even installed on this image until HSF/harvester#312, these warnings have likely been silently failing for two independent reasons; this fixes the second one so they'll actually deliver once that image update lands.

Uses the same pre-authorized address `panda-server`'s own `MailUtils.py` and the new shared-volume alert (#271) already send from (`atlas-adc-panda-no-reply@cern.ch`). Verified the `-r` flag with this exact pipe syntax locally before applying it here.