### PR TITLE
Bump iDDS image to 2.6.14 on ATLAS testbed and DOMA

### DIFF
--- a/helm/idds/values/values-atlas_testbed.yaml
+++ b/helm/idds/values/values-atlas_testbed.yaml
@@ -5,7 +5,7 @@
 rest:
   replicaCount: 1
   image:
-    tag: "2.6.13"
+    tag: "2.6.14"
   iddsServer: panda-idds-tb.cern.ch
   resources:
     requests:

--- a/helm/idds/values/values-doma-k8s.yaml
+++ b/helm/idds/values/values-doma-k8s.yaml
@@ -5,7 +5,7 @@
 rest:
   replicaCount: 1
   image:
-    tag: "2.6.13"
+    tag: "2.6.14"
   iddsServer: panda-idds-doma.cern.ch
 
   persistentvolume:


### PR DESCRIPTION
2.6.14 includes the NATS timeout exception handling fix (HSF/iDDS#564), merged and released upstream on 2026-08-04. Stops thousands of spurious "Failed to fetch event.Message" ERROR log lines on both clusters for what's just the normal "no messages waiting" condition on this idle service.